### PR TITLE
[READY] Debug headers for cache and sequence number

### DIFF
--- a/lib/alephant/broker.rb
+++ b/lib/alephant/broker.rb
@@ -38,7 +38,11 @@ module Alephant
       def send(response)
         [
           response.status,
-          { "Content-Type" => response.content_type },
+          {
+            "Content-Type" => response.content_type,
+            "X-Version"    => response.version.to_s,
+            "X-Cached"     => response.cached.to_s
+          },
           [ response.content.to_s ]
         ]
       end

--- a/lib/alephant/broker/component.rb
+++ b/lib/alephant/broker/component.rb
@@ -12,17 +12,19 @@ module Alephant
     class Component
       include Logger
 
-      attr_reader :id, :batch_id, :options, :content
+      attr_reader :id, :batch_id, :options, :content, :cached
 
       def initialize(id, batch_id, options)
         @id       = id
         @batch_id = batch_id
         @cache    = Cache::Client.new
         @options  = symbolize(options || {})
+        @cached   = true
       end
 
       def load
         @content ||= @cache.get(cache_key) do
+          @cached = false
           s3.get(s3_path)
         end
       end

--- a/lib/alephant/broker/response/asset.rb
+++ b/lib/alephant/broker/response/asset.rb
@@ -15,10 +15,12 @@ module Alephant
         end
 
         def setup
-          result  = load(component)
 
+          result  = load(component)
           @status  = result['status']
           @content = result['body']
+          @version = component.version.nil? ? 'not available' : component.version
+          @cached  = component.cached
         end
 
       end

--- a/lib/alephant/broker/response/base.rb
+++ b/lib/alephant/broker/response/base.rb
@@ -4,7 +4,7 @@ module Alephant
   module Broker
     module Response
       class Base
-        attr_accessor :status, :content, :content_type
+        attr_accessor :status, :content, :content_type, :version, :cached
 
         STATUS_CODE_MAPPING = {
           200 => 'ok',


### PR DESCRIPTION
This PR adds the following response headers:
- X-Cached - If the response was pulled from elasticache
- X-Version - The current version of the component

Currently this only works on the single component endpoint:

`/component/my_new_component`
