### PR TITLE
Version elasticache cache objects

### DIFF
--- a/lib/alephant/broker/cache.rb
+++ b/lib/alephant/broker/cache.rb
@@ -28,15 +28,17 @@ module Alephant
            Broker.config['elasticache_ttl'] || DEFAULT_TTL
         end
 
+        def versioned(key)
+          [key, cache_version].compact.join('_')
+        end
+
         def cache_version
-          Broker.config['elasticache_cache_version'] || ""
+          Broker.config['elasticache_cache_version']
         end
 
         def get(key, &block)
-          key += cache_version
-
           begin
-            result = @@client.get(key)
+            result = @@client.get(versioned(key))
             logger.info("Broker::Cache::Client#get key: #{key} - #{result ? 'hit' : 'miss'}")
             result ? result : set(key, block.call)
           rescue StandardError => e
@@ -45,9 +47,7 @@ module Alephant
         end
 
         def set(key, value)
-          key += cache_version
-
-          value.tap { |o| @@client.set(key, o) }
+          value.tap { |o| @@client.set(versioned(key), o) }
         end
 
       end


### PR DESCRIPTION
This prevents problems occurring when the structure of the cache objects change between releases.

To use, add the following into your application config that consumes this gem:

``` json
{
  "elasticache_cache_version": 10
}
```

Solves same problem as ~~https://github.com/BBC-News/alephant-broker/pull/13~~
