### PR TITLE
[Review] Enable loading components in parallel (batch)

### DIFF
--- a/lib/alephant/broker/request/batch.rb
+++ b/lib/alephant/broker/request/batch.rb
@@ -1,5 +1,6 @@
 require 'alephant/logger'
 require 'alephant/broker/component'
+require 'pmap'
 
 module Alephant
   module Broker
@@ -26,7 +27,7 @@ module Alephant
         end
 
         def components_for(env)
-          env.data['components'].map do |c|
+          env.data['components'].pmap do |c|
             @component_factory.create(
               c['component'],
               batch_id,

--- a/lib/alephant/broker/response/batch.rb
+++ b/lib/alephant/broker/response/batch.rb
@@ -1,5 +1,4 @@
 require 'alephant/logger'
-require 'pmap'
 
 module Alephant
   module Broker
@@ -27,7 +26,7 @@ module Alephant
 
         def json
           logger.info "Broker: Batch load started (#{batch_id})"
-          result = components.pmap do |component|
+          result = components.map do |component|
             {
               'component'    => component.id,
               'options'      => component.options,


### PR DESCRIPTION
![oxjjfnv - imgur](https://cloud.githubusercontent.com/assets/527874/4880413/15619b6e-633b-11e4-8f1e-8e9a308dac9d.gif)
### Problem

After testing the batch loading endpoint, it became apparent that the components are still loaded async and not in parallel in the [response](https://github.com/BBC-News/alephant-broker/blob/master/lib/alephant/broker/response/batch.rb#L30).

After having a look through the code, I realised that even though we're generating the json using pmap, we're doing the actual loading in the factory: https://github.com/BBC-News/alephant-broker/blob/master/lib/alephant/broker/component_factory.rb#L19.
### Solution

The changes I've made I tested in production and they worked in terms of doing the actual loading in parallel and brought the response time down dramatically.

I know there could be some knock on effects from these changes which is evident from the failing tests, but the in principal it works we just need to have a re-think about the error catching in the factory I think.
#### Edit by @revett

`.pmap` was being used in the wrong place ([BatchResponse](https://github.com/BBC-News/alephant-broker/blob/master/lib/alephant/broker/response/batch.rb#L30)), where the components had already been loaded (sequentially). I simply moved it to the [BatchRequest](https://github.com/BBC-News/alephant-broker/blob/master/lib/alephant/broker/request/batch.rb#L29) object so that the [ComponentFactory](https://github.com/BBC-News/alephant-broker/blob/master/lib/alephant/broker/component_factory.rb#L15) could initialize components in parallel. It handles errors (e.g. [ContentNotFound](https://github.com/BBC-News/alephant-broker/blob/master/lib/alephant/broker/component_factory.rb#L21)) in exactly the same way. :surfer: 
