### PR TITLE
Set custom TTL in Cache

### DIFF
--- a/lib/alephant/broker/cache.rb
+++ b/lib/alephant/broker/cache.rb
@@ -29,8 +29,8 @@ module Alephant
           end
         end
 
-        def set(key, value)
-          value.tap { |o| @@client.set(versioned(key), o) }
+        def set(key, value, ttl = nil)
+          value.tap { |o| @@client.set(versioned(key), o, ttl) }
         end
 
         private


### PR DESCRIPTION
Issue [#21](https://github.com/BBC-News/alephant-broker/issues/21) raised by @stevenjack.
#### Problem

Unable to set TTL on a per object basis, when using [Cache](https://github.com/BBC-News/alephant-broker/blob/master/lib/alephant/broker/cache.rb) class.
#### Solution
- Allow TTL to be set in [.set](https://github.com/BBC-News/alephant-broker/blob/master/lib/alephant/broker/cache.rb#L49) method.
- Have the TTL set to `nil` if no value is given.
- [Dalli](https://github.com/mperham/dalli/blob/master/lib/dalli/client.rb#L101) then defaults to the TTL given when the cache client was initialised, if TTL is `nil`.
- Therefore does not change current interface.

![image.gif](http://i.imgur.com/VnzsLOe.gif)
