### PR TITLE
[Bug] Toggle Stack Trace

### DIFF
--- a/lib/alephant/broker/error_component.rb
+++ b/lib/alephant/broker/error_component.rb
@@ -24,7 +24,13 @@ module Alephant
       private
 
       def content_for(exception)
-        "#{exception.message}\n#{exception.backtrace.join('\n')}"
+        "#{exception.message}".tap do |msg|
+          msg << "\n#{exception.backtrace.join('\n')}" if debug?
+        end
+      end
+
+      def debug?
+        Broker.config.fetch('debug', false)
       end
     end
   end


### PR DESCRIPTION
#### Problem

Currently when an error occurs in a **batch request**, the stack trace of the exception is included in the body of the JSON response. 
#### Solution

Toggle this behaviour based on a `debug` value in the config hash handed to the Broker (defaults to **false**).

![image.gif](http://media.giphy.com/media/ePYyTwoGI50aY/giphy.gif)
