### PR TITLE
Bug/url generate default params

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The HTML load strategy relies upon being given a URLGenerator, which is used to 
 * extend [`Alephant::Broker::LoadStrategy::HTTP::URL`](https://github.com/BBC-News/alephant-broker/blob/master/lib/alephant/broker/load_strategy/http.rb#L9-L13).
 * include a `#generate` method which takes `id` (string) and `options` (hash) as parameters.
 
-```
+```ruby
 require 'alephant/broker/load_strategy/http'
 require 'rack'
 


### PR DESCRIPTION
Relates to https://github.com/BBC-News/alephant-broker/issues/28 created by @revett.
#### Problem

Would have been nice for users to not have to include `id` and `options` as arguments for the `#generate` method in their custom UrlGenerator class - however because the HTTP strategy **always** hands the method two arguments, there is no way around it.
#### Solution

Improve documentation.

![woop.gif](http://giant.gfycat.com/RealisticVerifiableHarpseal.gif)
