### PR TITLE
[READY] Use correct opt hash

### DIFF
--- a/lib/alephant/broker/response/asset.rb
+++ b/lib/alephant/broker/response/asset.rb
@@ -25,7 +25,7 @@ module Alephant
 
         def details
           c = @component
-          "#{c.id}/#{c.opts_hash}/#{c.headers} #{batched} #{c.options}"
+          "#{c.id}/#{c.options}/#{c.headers} #{batched} #{c.options}"
         end
 
         def log


### PR DESCRIPTION
![thanks_mate](https://cloud.githubusercontent.com/assets/527874/5457419/603d3cdc-8542-11e4-8a62-97dd7a801b7e.gif)
### Problem

When logging the output for a single component, an exception was thrown when trying to generate the message so a 404 would actually end up returning a 500.
### Solution

Fix the typo.
