### PR TITLE
[READY] Fix issue where cache version was used instead of sequence for cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ run Alephant::Broker::Application.new(
 )
 ```
 
+### Cache version number
+
+The broker looks for a configuration value `elasticache_cache_version` and if it exists it uses it to construct the cache key.
+This allows the cache to be busted if the data in the cache changes, or for any other reason that it needs to be invalidated.
+
+This version is added as a header to the response in the following format:
+
+`X-Cache-Version: {CACHE_VERSION}`
+
+
 ## Contributing
 
 1. [Fork it!]( http://github.com/bbc-news/alephant-broker/fork)

--- a/lib/alephant/broker/cache.rb
+++ b/lib/alephant/broker/cache.rb
@@ -22,7 +22,8 @@ module Alephant
 
         def get(key, &block)
           begin
-            result = @@client.get(versioned(key))
+            key = versioned(key)
+            result = @@client.get key
             logger.info("Broker::Cache::Client#get key: #{key} - #{result ? 'hit' : 'miss'}")
             logger.metric(:name => "BrokerCacheClientGetKeyMiss", :unit => "Count", :value => 1) unless result
             result ? result : set(key, block.call)

--- a/lib/alephant/broker/component.rb
+++ b/lib/alephant/broker/component.rb
@@ -27,8 +27,6 @@ module Alephant
       def headers
         {
           'Content-Type' => data[:content_type].to_s,
-          'X-Version'    => meta.version.to_s,
-          'X-Cached'     => meta.cached.to_s
         }.merge(data[:headers] || {})
       end
 

--- a/lib/alephant/broker/component_meta.rb
+++ b/lib/alephant/broker/component_meta.rb
@@ -42,14 +42,6 @@ module Alephant
       def renderer_key
         "#{batch_id}/#{opts_hash}"
       end
-
-      def headers(data)
-        {
-          'Content-Type' => data[:content_type].to_s,
-          'X-Version'    => version.to_s,
-          'X-Cached'     => cached.to_s
-        }.merge(data[:headers] || {})
-      end
     end
   end
 end

--- a/lib/alephant/broker/component_meta.rb
+++ b/lib/alephant/broker/component_meta.rb
@@ -17,14 +17,14 @@ module Alephant
         Crimp.signature options
       end
 
+      def component_key
+        "#{id}/#{opts_hash}"
+      end
+
       private
 
       def convert_keys(hash)
         Hash[ hash.map { |k, v| [k.to_sym, v] } ]
-      end
-
-      def component_key
-        "#{id}/#{opts_hash}"
       end
 
       def renderer_key

--- a/lib/alephant/broker/component_meta.rb
+++ b/lib/alephant/broker/component_meta.rb
@@ -1,7 +1,7 @@
 module Alephant
   module Broker
     class ComponentMeta
-      attr_reader :id, :options, :batch_id, :opts_hash
+      attr_reader :id, :options, :batch_id
 
       def initialize(id, batch_id, options)
         @id          = id

--- a/lib/alephant/broker/component_meta.rb
+++ b/lib/alephant/broker/component_meta.rb
@@ -1,24 +1,12 @@
 module Alephant
   module Broker
     class ComponentMeta
-      attr_reader :id, :options, :batch_id
-      attr_accessor :cached
+      attr_reader :id, :options, :batch_id, :opts_hash
 
       def initialize(id, batch_id, options)
         @id          = id
         @batch_id    = batch_id
         @options     = convert_keys(options || {})
-        @cached      = true
-      end
-
-      def cache_key
-        "#{id}/#{opts_hash}/#{version}"
-      end
-
-      def version
-        Broker.config.fetch(
-          'elasticache_cache_version', 'not available'
-        ).to_s
       end
 
       def key

--- a/lib/alephant/broker/load_strategy/s3/base.rb
+++ b/lib/alephant/broker/load_strategy/s3/base.rb
@@ -94,8 +94,8 @@ module Alephant
 
           def headers(component_meta)
             {
-              'X-Version'    => Broker.config['elasticache_cache_version'].to_s,
-              'X-Cached'     => cached.to_s
+              'X-Cache-Version'    => Broker.config['elasticache_cache_version'].to_s,
+              'X-Cached'           => cached.to_s
             }
           end
         end

--- a/lib/alephant/broker/load_strategy/s3/base.rb
+++ b/lib/alephant/broker/load_strategy/s3/base.rb
@@ -9,6 +9,11 @@ module Alephant
       module S3
         class Base
           include Logger
+          attr_accessor :cached
+
+          def initialize
+            @cached = true
+          end
 
           def load(component_meta)
             add_s3_headers(
@@ -23,7 +28,7 @@ module Alephant
             )
             add_s3_headers(
               cache.set(
-                component_meta.cache_key,
+                cache_key(component_meta),
                 retrieve_object(component_meta)
               ),
               component_meta
@@ -34,6 +39,10 @@ module Alephant
 
           def headers(component_meta)
             Hash.new
+          end
+
+          def cache_key(component_meta)
+            component_meta.component_key
           end
 
           private
@@ -53,7 +62,7 @@ module Alephant
           end
 
           def retrieve_object(component_meta)
-            component_meta.cached = false
+            cached = false
             s3.get s3_path(component_meta)
           rescue AWS::S3::Errors::NoSuchKey, InvalidCacheKey
             logger.metric(
@@ -65,7 +74,7 @@ module Alephant
           end
 
           def cache_object(component_meta)
-            cache.get(component_meta.cache_key) do
+            cache.get cache_key(component_meta) do
               retrieve_object component_meta
             end
           end

--- a/lib/alephant/broker/load_strategy/s3/base.rb
+++ b/lib/alephant/broker/load_strategy/s3/base.rb
@@ -82,6 +82,13 @@ module Alephant
               Broker.config[:lookup_table_name]
             )
           end
+
+          def headers(component_meta)
+            {
+              'X-Version'    => Broker.config['elasticache_cache_version'].to_s,
+              'X-Cached'     => cached.to_s
+            }
+          end
         end
       end
     end

--- a/lib/alephant/broker/load_strategy/s3/sequenced.rb
+++ b/lib/alephant/broker/load_strategy/s3/sequenced.rb
@@ -6,7 +6,7 @@ module Alephant
       module S3
         class Sequenced < Base
           def sequence(component_meta)
-            @sequence ||= sequencer.get_last_seen component_meta.key
+            sequencer.get_last_seen component_meta.key
           end
 
           def s3_path(component_meta)
@@ -23,10 +23,6 @@ module Alephant
             @sequencer ||= Alephant::Sequencer.create(
               Broker.config[:sequencer_table_name], nil
             )
-          end
-
-          def version
-            @version ||= sequence(component_meta)
           end
 
           def cache_key(component_meta)

--- a/lib/alephant/broker/load_strategy/s3/sequenced.rb
+++ b/lib/alephant/broker/load_strategy/s3/sequenced.rb
@@ -28,6 +28,12 @@ module Alephant
               Broker.config[:sequencer_table_name], nil
             )
           end
+
+          def headers(component_meta)
+            {
+              "X-Sequence" => sequence(component_meta).to_s
+            }.merge(super(component_meta))
+          end
         end
       end
     end

--- a/lib/alephant/broker/load_strategy/s3/sequenced.rb
+++ b/lib/alephant/broker/load_strategy/s3/sequenced.rb
@@ -6,11 +6,7 @@ module Alephant
       module S3
         class Sequenced < Base
           def sequence(component_meta)
-            sequencer.get_last_seen component_meta.key
-          end
-
-          def headers(component_meta)
-            { "X-Sequence" => sequence(component_meta).to_s }
+            @sequence ||= sequencer.get_last_seen component_meta.key
           end
 
           def s3_path(component_meta)
@@ -27,6 +23,14 @@ module Alephant
             @sequencer ||= Alephant::Sequencer.create(
               Broker.config[:sequencer_table_name], nil
             )
+          end
+
+          def version
+            @version ||= sequence(component_meta)
+          end
+
+          def cache_key(component_meta)
+            "#{super(component_meta)}/#{sequence(component_meta)}"
           end
 
           def headers(component_meta)


### PR DESCRIPTION
![roll](https://cloud.githubusercontent.com/assets/527874/6233916/5a2ac3ba-b6ce-11e4-816a-19511fa29548.gif)

### Problem

After the load strategy refactor the sequencer was lost from the `component_meta` class and the cache version was used instead, which caused the cache key to be incorrectly generated and resulted in the content being cached indefinitely even after the sequence id changed.

### Solution

Move the cache key generation logic up into the load strategy classes, then the `sequenced` class extends the `cache_key` method in the base and adds the sequence id into the cache key.

* The cache version header has been renamed to something more appropriate.
* Readme has been updated to explain what that config param and header is.