### PR TITLE
Removes polling

### DIFF
--- a/lib/alephant/broker.rb
+++ b/lib/alephant/broker.rb
@@ -2,11 +2,9 @@ require 'alephant/broker/version'
 require 'alephant/broker/request'
 require 'alephant/broker/environment'
 require 'alephant/broker'
-require 'ostruct'
 
 module Alephant
   module Broker
-    @@poll = true
 
     def self.handle(load_strategy, env)
       Request::Handler.process(load_strategy, env)
@@ -20,14 +18,6 @@ module Alephant
       @@configuration = c
     end
 
-    def self.poll?
-      @@poll
-    end
-
-    def self.poll=(state)
-      @@poll = state
-    end
-
     class Application
       attr_reader :load_strategy
 
@@ -37,11 +27,7 @@ module Alephant
       end
 
       def call(env)
-        if ::Alephant::Broker.poll?
-          send response_for(environment_for(env))
-        else
-          send stop_poll_response
-        end
+        send response_for(environment_for(env))
       end
 
       def environment_for(env)
@@ -60,23 +46,6 @@ module Alephant
             response.content.to_s
           ]
         ]
-      end
-
-      private
-
-      def stop_poll_response
-        response = OpenStruct.new(
-          :status   => 420,
-          :content  => "Stopped polling",
-          :cached   => false,
-          :version  => 0,
-          :sequence => 0,
-          :headers => {
-            "Content-Type"   => "plain/text",
-            "X-Cached"       => "false",
-            "X-Stop-Polling" => "true"
-          }
-        )
       end
     end
   end


### PR DESCRIPTION
![laser](https://cloud.githubusercontent.com/assets/527874/6246061/b67ba89e-b75c-11e4-834b-5288ceb175b3.gif)

### Problem

The polling code has been sitting around for a while and is never used. Whilst refactoring to fix it up for rubocop it complained a lot about the code.

### Solution

Remove it.