### PR TITLE
[READY] Pass unversioned key to set method

### DIFF
--- a/lib/alephant/broker/cache.rb
+++ b/lib/alephant/broker/cache.rb
@@ -22,9 +22,9 @@ module Alephant
 
         def get(key, &block)
           begin
-            key = versioned(key)
-            result = @@client.get key
-            logger.info("Broker::Cache::Client#get key: #{key} - #{result ? 'hit' : 'miss'}")
+            versioned_key = versioned key
+            result = @@client.get versioned_key
+            logger.info("Broker::Cache::Client#get key: #{versioned_key} - #{result ? 'hit' : 'miss'}")
             logger.metric(:name => "BrokerCacheClientGetKeyMiss", :unit => "Count", :value => 1) unless result
             result ? result : set(key, block.call)
           rescue StandardError => e


### PR DESCRIPTION
![rqnf2ou - imgur](https://cloud.githubusercontent.com/assets/527874/6689833/b823b566-ccb4-11e4-8806-37f131e66ba0.gif)

### Problem

The key had the version number added to it before trying to retrieve content from the cache, then this versioned key was passed along to the set method where it was versioned again - meaning the cached version was never retrievable.

### Solution

Pass the unversioned key to the `set` method.