### PR TITLE
[READY] Adds headers from alephant-cache to response

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ notifications:
     on_failure: change
     on_success: never
 sudo: false
+script: bundle exec rake all

--- a/lib/alephant/broker/component.rb
+++ b/lib/alephant/broker/component.rb
@@ -1,9 +1,9 @@
-require 'crimp'
-require 'alephant/cache'
-require 'alephant/lookup'
-require 'alephant/broker/errors/invalid_cache_key'
-require 'alephant/sequencer'
-require 'alephant/broker/cache'
+require "crimp"
+require "alephant/cache"
+require "alephant/lookup"
+require "alephant/broker/errors/invalid_cache_key"
+require "alephant/sequencer"
+require "alephant/broker/cache"
 
 module Alephant
   module Broker
@@ -14,32 +14,42 @@ module Alephant
         @id        = meta.id
         @batch_id  = meta.batch_id
         @options   = symbolize(meta.options || {})
-        @content   = data[:content].force_encoding 'UTF-8'
+        @content   = data[:content].force_encoding "UTF-8"
         @opts_hash = meta.opts_hash
         @data      = data
         @meta      = meta
       end
 
       def content_type
-        headers['Content-Type']
+        headers["Content-Type"]
       end
 
       def headers
         {
-          'Content-Type' => data[:content_type].to_s,
-        }.merge(data[:headers] || {})
+          "Content-Type" => data[:content_type].to_s
+        }
+          .merge(data[:headers] || {})
+          .merge(stripped_headers)
       end
 
       def status
-        200
+        meta_data_headers.key?("Status") ? meta_data_headers["Status"] : 200
       end
 
       private
 
       attr_reader :meta, :data
 
+      def meta_data_headers
+        @meta_data_headers ||= data[:meta].fetch(:headers, {})
+      end
+
+      def stripped_headers
+        meta_data_headers.reject { |k, _| k == "Status" }
+      end
+
       def symbolize(hash)
-        Hash[hash.map { |k,v| [k.to_sym, v] }]
+        Hash[hash.map { |k, v| [k.to_sym, v] }]
       end
     end
   end

--- a/spec/fixtures/json/batch_compiled.json
+++ b/spec/fixtures/json/batch_compiled.json
@@ -1,1 +1,1 @@
-{"batch_id":"baz","components":[{"component":"ni_council_results_table","options":{"foo" : "bar"},"status":200,"content_type":"foo/bar","body":"Test"},{"component":"ni_council_results_table","options":{},"status":200,"content_type":"foo/bar","body":"Test"}]}
+{"batch_id":"baz","components":[{"component":"ni_council_results_table","options":{"foo":"bar"},"status":200,"content_type":"test/content","body":"Test"},{"component":"ni_council_results_table","options":{},"status":200,"content_type":"test/content","body":"Test"}]}

--- a/spec/integration/rack_spec.rb
+++ b/spec/integration/rack_spec.rb
@@ -80,7 +80,7 @@ describe Alephant::Broker::Application do
   end
 
   describe "Components endpoint '/components'" do
-    let(:fixture_path) { "#{File.dirname(__FILE__)}/fixtures/json" }
+    let(:fixture_path) { "#{File.dirname(__FILE__)}/../fixtures/json" }
     let(:batch_json) do
       IO.read("#{fixture_path}/batch.json").strip
     end


### PR DESCRIPTION
![vx1ziwe - imgur](https://cloud.githubusercontent.com/assets/527874/6901482/600c027e-d705-11e4-890d-178fbbaadde7.gif)

### Problem

Currently the broker has no way on expressing headers based on the content stored in s3. There's a couple of requirements we have now:

* Allow the status code to be set based on what was written at the point of render.
* Allow other arbitrary headers to be set, for example the `Cache-Control` lifetime of an object so upstream proxies can cache appropriately.

at the moment there's no way of doing this.

### Solution

Add another node in the the `:meta` node of the s3 object called `:headers`. This then includes all headers you want to add to the response when the broker serves up the object. 