### PR TITLE
[READY] Fix meta data issue

### DIFF
--- a/lib/alephant/broker/component.rb
+++ b/lib/alephant/broker/component.rb
@@ -35,7 +35,7 @@ module Alephant
       end
 
       def status
-        data[:meta].key?("Status") ? data[:meta]["Status"] : 200
+        data[:meta].key?("status") ? data[:meta]["status"] : 200
       end
 
       private
@@ -43,14 +43,14 @@ module Alephant
       attr_reader :meta, :data
 
       def meta_data_headers
-        @meta_data_headers ||= data[:meta].reduce({}) do |accum, (k, v)|
+        @meta_data_headers ||= data[:meta].to_h.reduce({}) do |accum, (k, v)|
           accum.tap do |a|
-            a[interpolated_header_key(k)] = v if k.start_with? HEADER_PREFIX
+            a[header_key(k)] = v.to_s if k.start_with?(HEADER_PREFIX)
           end
         end
       end
 
-      def interpolated_header_key(key)
+      def header_key(key)
         key.gsub(HEADER_PREFIX, "").split("-").map(&:capitalize).join("-")
       end
 

--- a/lib/alephant/broker/component.rb
+++ b/lib/alephant/broker/component.rb
@@ -45,9 +45,13 @@ module Alephant
       def meta_data_headers
         @meta_data_headers ||= data[:meta].reduce({}) do |accum, (k, v)|
           accum.tap do |a|
-            a[k.gsub(HEADER_PREFIX, "")] = v if k.start_with? HEADER_PREFIX
+            a[interpolated_header_key(k)] = v if k.start_with? HEADER_PREFIX
           end
         end
+      end
+
+      def interpolated_header_key(key)
+        key.gsub(HEADER_PREFIX, "").split("-").map(&:capitalize).join("-")
       end
 
       def symbolize(hash)

--- a/lib/alephant/broker/component.rb
+++ b/lib/alephant/broker/component.rb
@@ -10,6 +10,8 @@ module Alephant
     class Component
       attr_reader :id, :batch_id, :options, :content, :opts_hash
 
+      HEADER_PREFIX = "head_"
+
       def initialize(meta, data)
         @id        = meta.id
         @batch_id  = meta.batch_id
@@ -29,11 +31,11 @@ module Alephant
           "Content-Type" => data[:content_type].to_s
         }
           .merge(data[:headers] || {})
-          .merge(stripped_headers)
+          .merge(meta_data_headers)
       end
 
       def status
-        meta_data_headers.key?("Status") ? meta_data_headers["Status"] : 200
+        data[:meta].key?("Status") ? data[:meta]["Status"] : 200
       end
 
       private
@@ -41,11 +43,11 @@ module Alephant
       attr_reader :meta, :data
 
       def meta_data_headers
-        @meta_data_headers ||= data[:meta].fetch(:headers, {})
-      end
-
-      def stripped_headers
-        meta_data_headers.reject { |k, _| k == "Status" }
+        @meta_data_headers ||= data[:meta].reduce({}) do |accum, (k, v)|
+          accum.tap do |a|
+            a[k.gsub(HEADER_PREFIX, "")] = v if k.start_with? HEADER_PREFIX
+          end
+        end
       end
 
       def symbolize(hash)

--- a/spec/integration/rack_spec.rb
+++ b/spec/integration/rack_spec.rb
@@ -129,9 +129,10 @@ describe Alephant::Broker::Application do
     context "with cache and additional headers set" do
       before do
         content[:meta] = {
-          "head_cache-control" => "max-age=60",
-          "head_x-some-header" => "foo",
-          "status"             => 200
+          "head_cache-control"       => "max-age=60",
+          "head_x-some-header"       => "foo",
+          "head_header_without_dash" => "bar",
+          "status"                   => 200
         }
         allow(Alephant::Cache).to receive(:new) { s3_cache_double }
         get "/component/test_component"
@@ -152,6 +153,12 @@ describe Alephant::Broker::Application do
         expect(
           last_response.headers
         ).to include_case_sensitive("X-Some-Header")
+      end
+
+      specify do
+        expect(
+          last_response.headers
+        ).to include_case_sensitive("Header_without_dash")
       end
 
       specify { expect(last_response.headers).to_not include("Status") }

--- a/spec/integration/rack_spec.rb
+++ b/spec/integration/rack_spec.rb
@@ -106,9 +106,7 @@ describe Alephant::Broker::Application do
     let(:content) do
       {
         :content => "missing_content",
-        :meta    => {
-          :headers => {}
-        }
+        :meta    => {}
       }
     end
     let(:s3_cache_double) do
@@ -120,7 +118,7 @@ describe Alephant::Broker::Application do
 
     context "with 404 status code set" do
       before do
-        content[:meta][:headers]["Status"] = 404
+        content[:meta]["Status"] = 404
         allow(Alephant::Cache).to receive(:new) { s3_cache_double }
         get "/component/test_component"
       end
@@ -130,10 +128,10 @@ describe Alephant::Broker::Application do
 
     context "with cache and additional headers set" do
       before do
-        content[:meta][:headers] = {
-          "Cache-Control" => "max-age=60",
-          "X-Some-Header" => "foo",
-          "Status"        => 200
+        content[:meta] = {
+          "head_Cache-Control" => "max-age=60",
+          "head_X-Some-Header" => "foo",
+          "Status"             => 200
         }
         allow(Alephant::Cache).to receive(:new) { s3_cache_double }
         get "/component/test_component"

--- a/spec/integration/rack_spec.rb
+++ b/spec/integration/rack_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require_relative "spec_helper"
 
 describe Alephant::Broker::Application do
   include Rack::Test::Methods
@@ -139,7 +139,7 @@ describe Alephant::Broker::Application do
 
       specify { expect(last_response.headers).to include_case_sensitive("Cache-Control") }
 
-      specify { expect(last_response.headers).to include("X-Some-Header") }
+      specify { expect(last_response.headers).to include_case_sensitive("X-Some-Header") }
       specify { expect(last_response.headers).to_not include("Status") }
       specify { expect(last_response.status).to eq 200 }
     end

--- a/spec/integration/rack_spec.rb
+++ b/spec/integration/rack_spec.rb
@@ -129,15 +129,16 @@ describe Alephant::Broker::Application do
     context "with cache and additional headers set" do
       before do
         content[:meta] = {
-          "head_Cache-Control" => "max-age=60",
-          "head_X-Some-Header" => "foo",
-          "Status"             => 200
+          "head_cache-control" => "max-age=60",
+          "head_x-some-header" => "foo",
+          "status"             => 200
         }
         allow(Alephant::Cache).to receive(:new) { s3_cache_double }
         get "/component/test_component"
       end
 
-      specify { expect(last_response.headers).to include("Cache-Control") }
+      specify { expect(last_response.headers).to include_case_sensitive("Cache-Control") }
+
       specify { expect(last_response.headers).to include("X-Some-Header") }
       specify { expect(last_response.headers).to_not include("Status") }
       specify { expect(last_response.status).to eq 200 }

--- a/spec/integration/rack_spec.rb
+++ b/spec/integration/rack_spec.rb
@@ -17,11 +17,11 @@ describe Alephant::Broker::Application do
     )
   end
   let(:content) do
-    {
+    AWS::Core::Data.new(
       :content_type => "test/content",
       :content      => "Test",
       :meta         => {}
-    }
+    )
   end
   let(:sequencer_double) do
     instance_double(
@@ -104,10 +104,10 @@ describe Alephant::Broker::Application do
 
   describe "S3 headers" do
     let(:content) do
-      {
+      AWS::Core::Data.new(
         :content => "missing_content",
         :meta    => {}
-      }
+      )
     end
     let(:s3_cache_double) do
       instance_double(
@@ -118,7 +118,7 @@ describe Alephant::Broker::Application do
 
     context "with 404 status code set" do
       before do
-        content[:meta]["Status"] = 404
+        content[:meta]["status"] = 404
         allow(Alephant::Cache).to receive(:new) { s3_cache_double }
         get "/component/test_component"
       end
@@ -137,9 +137,23 @@ describe Alephant::Broker::Application do
         get "/component/test_component"
       end
 
-      specify { expect(last_response.headers).to include_case_sensitive("Cache-Control") }
+      specify do
+        expect(
+          last_response.headers
+        ).to include_case_sensitive("Cache-Control")
+      end
+      specify do
+        expect(
+          last_response.headers["Cache-Control"]
+        ).to eq(content[:meta]["head_cache-control"])
+      end
 
-      specify { expect(last_response.headers).to include_case_sensitive("X-Some-Header") }
+      specify do
+        expect(
+          last_response.headers
+        ).to include_case_sensitive("X-Some-Header")
+      end
+
       specify { expect(last_response.headers).to_not include("Status") }
       specify { expect(last_response.status).to eq 200 }
     end

--- a/spec/integration/spec_helper.rb
+++ b/spec/integration/spec_helper.rb
@@ -6,5 +6,3 @@ RSpec::Matchers.define :include_case_sensitive do |expected|
     actual.keys.one? { |k| expected == k }
   end
 end
-
-

--- a/spec/integration/spec_helper.rb
+++ b/spec/integration/spec_helper.rb
@@ -1,1 +1,10 @@
-require_relative '../spec_helper'
+require_relative "../spec_helper"
+require "rspec/expectations"
+
+RSpec::Matchers.define :include_case_sensitive do |expected|
+  match do |actual|
+    actual.keys.one? { |k| expected == k }
+  end
+end
+
+


### PR DESCRIPTION
![glove](https://cloud.githubusercontent.com/assets/527874/6939594/363bc49a-d866-11e4-8108-6ab45f4d6b2a.gif)

### Problem

The metadata keys for an object are just flat `key => value` pairs and can't contain a nested hash.

### Solution

Each key that is should be passed back as a header through the broker is prepended with `head_`. These keys are taken out of the metadata, the prefix stripped and capitalised.