### PR TITLE
Update to latest logger

### DIFF
--- a/alephant-broker.gemspec
+++ b/alephant-broker.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "alephant-lookup"
   spec.add_runtime_dependency "alephant-cache"
-  spec.add_runtime_dependency "alephant-logger", "~> 1"
+  spec.add_runtime_dependency "alephant-logger", "1.2.0"
   spec.add_runtime_dependency 'alephant-sequencer'
   spec.add_runtime_dependency "dalli-elasticache"
   spec.add_runtime_dependency "pmap"

--- a/lib/alephant/broker/cache.rb
+++ b/lib/alephant/broker/cache.rb
@@ -14,7 +14,7 @@ module Alephant
             @@elasticache ||= ::Dalli::ElastiCache.new(config_endpoint, { :expires_in => ttl })
             @@client ||= @@elasticache.client
           else
-            logger.debug('Broker::Cache::Client#initialize: No config endpoint, NullClient used')
+            logger.debug "Broker::Cache::Client#initialize: No config endpoint, NullClient used"
             logger.metric("NoConfigEndpoint", dimensions.merge(:function => "initialize"))
             @@client = NullClient.new
           end
@@ -24,7 +24,7 @@ module Alephant
           begin
             versioned_key = versioned key
             result = @@client.get versioned_key
-            logger.info("Broker::Cache::Client#get key: #{versioned_key} - #{result ? 'hit' : 'miss'}")
+            logger.info "Broker::Cache::Client#get key: #{versioned_key} - #{result ? 'hit' : 'miss'}"
             logger.metric(
               "GetKeyMiss",
               opts[:dimensions].merge(:function => "get")

--- a/lib/alephant/broker/cache.rb
+++ b/lib/alephant/broker/cache.rb
@@ -15,7 +15,7 @@ module Alephant
             @@client ||= @@elasticache.client
           else
             logger.debug "Broker::Cache::Client#initialize: No config endpoint, NullClient used"
-            logger.metric("NoConfigEndpoint", dimensions.merge(:function => "initialize"))
+            logger.metric("NoConfigEndpoint", opts.merge(:function => "initialize"))
             @@client = NullClient.new
           end
         end

--- a/lib/alephant/broker/cache.rb
+++ b/lib/alephant/broker/cache.rb
@@ -15,7 +15,7 @@ module Alephant
             @@client ||= @@elasticache.client
           else
             logger.debug('Broker::Cache::Client#initialize: No config endpoint, NullClient used')
-            logger.metric("BrokerCacheClientNoConfigEndpoint", dimensions.merge(:function => "initialize"))
+            logger.metric("NoConfigEndpoint", dimensions.merge(:function => "initialize"))
             @@client = NullClient.new
           end
         end
@@ -26,7 +26,7 @@ module Alephant
             result = @@client.get versioned_key
             logger.info("Broker::Cache::Client#get key: #{versioned_key} - #{result ? 'hit' : 'miss'}")
             logger.metric(
-              "BrokerCacheClientGetKeyMiss",
+              "GetKeyMiss",
               opts[:dimensions].merge(:function => "get")
             ) unless result
             result ? result : set(key, block.call)
@@ -77,4 +77,3 @@ module Alephant
     end
   end
 end
-

--- a/lib/alephant/broker/component_factory.rb
+++ b/lib/alephant/broker/component_factory.rb
@@ -20,12 +20,24 @@ module Alephant
         )
       rescue Alephant::Broker::Errors::ContentNotFound => e
         logger.warn 'Broker.ComponentFactory.create: Exception raised (ContentNotFound)'
-        logger.metric(:name => "BrokerComponentFactoryContentNotFound", :unit => "Count", :value => 1)
+        logger.metric("BrokerComponentFactoryContentNotFound", opts)
         ErrorComponent.new(component_meta, 404, e)
       rescue => e
         logger.warn("Broker.ComponentFactory.create: Exception raised (#{e.message}, #{e.backtrace.join('\n')})")
-        logger.metric(:name => "BrokerComponentFactoryExceptionRaised", :unit => "Count", :value => 1)
+        logger.metric("BrokerComponentFactoryExceptionRaised", opts)
         ErrorComponent.new(component_meta, 500, e)
+      end
+
+      private
+
+      def opts
+        {
+          :dimensions => {
+            :module   => "AlephantBroker",
+            :class    => "ComponentFactory",
+            :function => "create"
+          }
+        }
       end
     end
   end

--- a/lib/alephant/broker/component_factory.rb
+++ b/lib/alephant/broker/component_factory.rb
@@ -20,11 +20,11 @@ module Alephant
         )
       rescue Alephant::Broker::Errors::ContentNotFound => e
         logger.warn 'Broker.ComponentFactory.create: Exception raised (ContentNotFound)'
-        logger.metric("BrokerComponentFactoryContentNotFound", opts)
+        logger.metric("ContentNotFound", opts)
         ErrorComponent.new(component_meta, 404, e)
       rescue => e
         logger.warn("Broker.ComponentFactory.create: Exception raised (#{e.message}, #{e.backtrace.join('\n')})")
-        logger.metric("BrokerComponentFactoryExceptionRaised", opts)
+        logger.metric("ExceptionRaised", opts)
         ErrorComponent.new(component_meta, 500, e)
       end
 

--- a/lib/alephant/broker/component_factory.rb
+++ b/lib/alephant/broker/component_factory.rb
@@ -19,11 +19,11 @@ module Alephant
           @load_strategy.load(component_meta)
         )
       rescue Alephant::Broker::Errors::ContentNotFound => e
-        logger.warn 'Broker.ComponentFactory.create: Exception raised (ContentNotFound)'
+        logger.warn "Broker.ComponentFactory.create: Exception raised (ContentNotFound)"
         logger.metric("ContentNotFound", opts)
         ErrorComponent.new(component_meta, 404, e)
       rescue => e
-        logger.warn("Broker.ComponentFactory.create: Exception raised (#{e.message}, #{e.backtrace.join('\n')})")
+        logger.warn "Broker.ComponentFactory.create: Exception raised (#{e.message}, #{e.backtrace.join('\n')})"
         logger.metric("ExceptionRaised", opts)
         ErrorComponent.new(component_meta, 500, e)
       end

--- a/lib/alephant/broker/environment.rb
+++ b/lib/alephant/broker/environment.rb
@@ -51,9 +51,19 @@ module Alephant
           JSON.parse(json)
         rescue JSON::ParserError => e
           logger.warn("Broker.environment#data: ParserError")
-          logger.metric(:name => "BrokerEnvironmentJSONParserError", :unit => "Count", :value => 1)
+          logger.metric("BrokerEnvironmentJSONParserError", opts)
           nil
         end
+      end
+
+      def opts
+        {
+          :dimensions => {
+            :module   => "AlephantBroker",
+            :class    => "Environment",
+            :function => "parse"
+          }
+        }
       end
     end
   end

--- a/lib/alephant/broker/environment.rb
+++ b/lib/alephant/broker/environment.rb
@@ -50,7 +50,7 @@ module Alephant
         begin
           JSON.parse(json)
         rescue JSON::ParserError => e
-          logger.warn("Broker.environment#data: ParserError")
+          logger.warn "Broker.environment#data: ParserError"
           logger.metric("BrokerEnvironmentJSONParserError", opts)
           nil
         end

--- a/lib/alephant/broker/environment.rb
+++ b/lib/alephant/broker/environment.rb
@@ -51,7 +51,7 @@ module Alephant
           JSON.parse(json)
         rescue JSON::ParserError => e
           logger.warn "Broker.environment#data: ParserError"
-          logger.metric("BrokerEnvironmentJSONParserError", opts)
+          logger.metric("JSONParserError", opts)
           nil
         end
       end

--- a/lib/alephant/broker/load_strategy/http.rb
+++ b/lib/alephant/broker/load_strategy/http.rb
@@ -23,7 +23,7 @@ module Alephant
           cache_object(component_meta)
         rescue
           logger.metric(
-            "BrokerLoadStrategyHTTPCacheMiss",
+            "CacheMiss",
             opts[:dimensions].merge(:function => "load")
           )
           cache.set(component_meta.cache_key, content(component_meta))
@@ -60,7 +60,7 @@ module Alephant
           Faraday.get(url_for component_meta).tap do |r|
             unless r.success?
               logger.metric(
-                "BrokerLoadStrategyHTTPContentNotFound",
+                "ContentNotFound",
                 opts[:dimensions].merge(:function => "request")
               )
               raise Alephant::Broker::Errors::ContentNotFound

--- a/lib/alephant/broker/load_strategy/http.rb
+++ b/lib/alephant/broker/load_strategy/http.rb
@@ -67,7 +67,7 @@ module Alephant
             end
 
             request_time = Time.new - before
-            logger.metric("BrokerHTTPLoadComponentTime", opts.merge(
+            logger.metric("LoadComponentTime", opts.merge(
               :unit  => "Seconds", :value => request_time,
             ).tap { |h| h[:dimensions].merge!(:function => "request") })
           end

--- a/lib/alephant/broker/load_strategy/http.rb
+++ b/lib/alephant/broker/load_strategy/http.rb
@@ -22,7 +22,10 @@ module Alephant
         def load(component_meta)
           cache_object(component_meta)
         rescue
-          logger.metric(:name => "BrokerLoadStrategyHTTPCacheMiss", :unit => "Count", :value => 1)
+          logger.metric(
+            "BrokerLoadStrategyHTTPCacheMiss",
+            opts[:dimensions].merge(:function => "load")
+          )
           cache.set(component_meta.cache_key, content(component_meta))
         end
 
@@ -56,12 +59,17 @@ module Alephant
 
           Faraday.get(url_for component_meta).tap do |r|
             unless r.success?
-              logger.metric(:name => "BrokerLoadStrategyHTTPContentNotFound", :unit => "Count", :value => 1)
+              logger.metric(
+                "BrokerLoadStrategyHTTPContentNotFound",
+                opts[:dimensions].merge(:function => "request")
+              )
               raise Alephant::Broker::Errors::ContentNotFound
             end
 
             request_time = Time.new - before
-            logger.metric(:name => "BrokerHTTPLoadComponentTime", :unit => "Seconds", :value => request_time)
+            logger.metric("BrokerHTTPLoadComponentTime", opts.merge(
+              :unit  => "Seconds", :value => request_time,
+            ).tap { |h| h[:dimensions].merge!(:function => "request") })
           end
         end
 
@@ -70,6 +78,15 @@ module Alephant
             component_meta.id,
             component_meta.options
           )
+        end
+
+        def opts
+          {
+            :dimensions => {
+              :module   => "AlephantBrokerLoadStrategy",
+              :class    => "HTTP"
+            }
+          }
         end
       end
     end

--- a/lib/alephant/broker/load_strategy/s3/base.rb
+++ b/lib/alephant/broker/load_strategy/s3/base.rb
@@ -22,7 +22,7 @@ module Alephant
             )
           rescue
             logger.metric(
-              "BrokerLoadStrategyS3CacheMiss",
+              "S3CacheMiss",
               opts[:dimensions].merge(:function => "load")
             )
             add_s3_headers(
@@ -74,7 +74,7 @@ module Alephant
             s3.get s3_path(component_meta)
           rescue AWS::S3::Errors::NoSuchKey, InvalidCacheKey
             logger.metric(
-              "BrokerLoadStrategyS3InvalidCacheKey",
+              "S3InvalidCacheKey",
               opts[:dimensions].merge(:function => "retrieve_object")
             )
             raise Alephant::Broker::Errors::ContentNotFound

--- a/lib/alephant/broker/load_strategy/s3/base.rb
+++ b/lib/alephant/broker/load_strategy/s3/base.rb
@@ -22,9 +22,8 @@ module Alephant
             )
           rescue
             logger.metric(
-              :name  => "BrokerLoadStrategyS3CacheMiss",
-              :unit  => "Count",
-              :value => 1
+              "BrokerLoadStrategyS3CacheMiss",
+              opts[:dimensions].merge(:function => "load")
             )
             add_s3_headers(
               cache.set(
@@ -47,6 +46,15 @@ module Alephant
 
           private
 
+          def opts
+            {
+              :dimensions => {
+                :module   => "AlephantBrokerLoadStrategyS3",
+                :class    => "Base"
+              }
+            }
+          end
+
           def s3_path(component_meta)
             fail NotImplementedError
           end
@@ -66,9 +74,8 @@ module Alephant
             s3.get s3_path(component_meta)
           rescue AWS::S3::Errors::NoSuchKey, InvalidCacheKey
             logger.metric(
-              :name  => "BrokerLoadStrategyS3InvalidCacheKey",
-              :unit  => "Count",
-              :value => 1
+              "BrokerLoadStrategyS3InvalidCacheKey",
+              opts[:dimensions].merge(:function => "retrieve_object")
             )
             raise Alephant::Broker::Errors::ContentNotFound
           end

--- a/lib/alephant/broker/request/asset.rb
+++ b/lib/alephant/broker/request/asset.rb
@@ -17,14 +17,24 @@ module Alephant
             env.options
           )
         rescue InvalidAssetId
-          logger.metric(:name => "BrokerRequestAssetInvalidAssetId", :unit => "Count", :value => 1)
-          logger.warn 'Broker.Request.Asset.initialize: Exception raised (InvalidAssetId)'
+          logger.metric("BrokerRequestAssetInvalidAssetId", opts)
+          logger.error 'Broker.Request.Asset.initialize: Exception raised (InvalidAssetId)'
         end
 
         private
 
         def component_id(path)
           path.split('/')[2] || (raise InvalidAssetId.new 'No Asset ID specified')
+        end
+
+        def opts
+          {
+            :dimensions => {
+              :module   => "AlephantBrokerRequest",
+              :class    => "Asset",
+              :function => "initialize"
+            }
+          }
         end
       end
     end

--- a/lib/alephant/broker/request/asset.rb
+++ b/lib/alephant/broker/request/asset.rb
@@ -18,7 +18,7 @@ module Alephant
           )
         rescue InvalidAssetId
           logger.metric("BrokerRequestAssetInvalidAssetId", opts)
-          logger.error 'Broker.Request.Asset.initialize: Exception raised (InvalidAssetId)'
+          logger.error "Broker.Request.Asset.initialize: Exception raised (InvalidAssetId)"
         end
 
         private

--- a/lib/alephant/broker/request/asset.rb
+++ b/lib/alephant/broker/request/asset.rb
@@ -17,7 +17,7 @@ module Alephant
             env.options
           )
         rescue InvalidAssetId
-          logger.metric("BrokerRequestAssetInvalidAssetId", opts)
+          logger.metric("InvalidAssetId", opts)
           logger.error "Broker.Request.Asset.initialize: Exception raised (InvalidAssetId)"
         end
 

--- a/lib/alephant/broker/response/base.rb
+++ b/lib/alephant/broker/response/base.rb
@@ -47,11 +47,17 @@ module Alephant
         end
 
         def log
-          logger.metric(
-            :name  => "BrokerResponse#{status}",
-            :unit  => "Count",
-            :value => 1
-          )
+          logger.metric("BrokerResponse#{status}", opts)
+        end
+
+        def opts
+          {
+            :dimensions => {
+              :module   => "AlephantBrokerResponse",
+              :class    => "Base",
+              :function => "log"
+            }
+          }
         end
       end
     end


### PR DESCRIPTION
## Problem

The Alephant Broker is used by Newbeat which is using an updated CloudWatch logger (the CloudWatch logger now has an updated interface). 

## Solution

We need to modify Alephant Broker to use the latest Alephant Logger (as that's what the updated Alephant CloudWatch Logger uses). Then update the `metric` calls to match the new interface.

## Release Plan

I believe this will be a patch release rather than a minor or major.

Existing projects will need their Gemfiles updated at some point soon to point to the older version of the broker (as I don't believe we anchor gems to specific versions in all projects), so when older projects get deployed they just go ahead and grab the latest version of the broker gem which will use a different logger than probably expected.