### PR TITLE
[READY] Adds no-cache headers for non 200 responses

### DIFF
--- a/spec/integration/rack_spec.rb
+++ b/spec/integration/rack_spec.rb
@@ -59,6 +59,9 @@ describe Alephant::Broker::Application do
     before { get "/banana" }
     specify { expect(last_response.status).to eql 404 }
     specify { expect(last_response.body).to eq "Not found" }
+    specify { expect(last_response.headers).to include("Cache-Control") }
+    specify { expect(last_response.headers).to include("Pragma") }
+    specify { expect(last_response.headers).to include("Expires") }
   end
 
   describe "Component endpoint '/component/...'" do


### PR DESCRIPTION
![april](https://cloud.githubusercontent.com/assets/527874/6946627/a65aba5a-d899-11e4-9e21-b810030544f7.gif)

### Problem

When the broker returns a non 200 response (Not one specified in the metadata `Status` header), no headers are sent to indicate the response shouldn't be cached upstream.

### Solution

For any non 200 response, send back the following headers:

```ruby
{
"Cache-Control" => "no-cache, must-revalidate",
"Pragma"        => "no-cache",
"Expires"       => "{Date in the past}"
}
```