### PR TITLE
Add missing log context

### DIFF
--- a/lib/alephant/broker/component_factory.rb
+++ b/lib/alephant/broker/component_factory.rb
@@ -19,7 +19,7 @@ module Alephant
           @load_strategy.load(component_meta)
         )
       rescue Alephant::Broker::Errors::ContentNotFound => e
-        logger.warn "Broker.ComponentFactory.create: Exception raised (ContentNotFound)"
+        logger.warn "Broker.ComponentFactory.create: Exception raised (ContentNotFound) for #{component_meta.component_key}"
         logger.metric "ContentNotFound"
         ErrorComponent.new(component_meta, 404, e)
       rescue => e


### PR DESCRIPTION
![getinsertpic.com](http://media0.giphy.com/media/urpk0OqOEDEEE/200.gif)
*^ it's 3am... help me*

## Problem

In the logs we were seeing a few log messages like...

```
WARN -- : Broker.ComponentFactory.create: Exception raised (ContentNotFound)
```

...but we had no context (without manually `grep`ing the app logs on individual instances)

## Solution

Add a little more context from the `ComponentMeta` object so it looks like...

```
WARN -- : Broker.ComponentFactory.create: Exception raised (ContentNotFound) for constituencies_candidates_results/244d13b0789b0e72bb3984fb902e4123
```

## Gem Release Process

This should be a patch release to `3.5.3`