### PR TITLE
Add headers to broker

### DIFF
--- a/lib/alephant/broker/response/asset.rb
+++ b/lib/alephant/broker/response/asset.rb
@@ -12,7 +12,7 @@ module Alephant
         end
 
         def setup
-          @headers  = @component.headers
+          @headers.merge!(@component.headers)
           @content  = @component.content
           log if @component.is_a? Component
         end

--- a/lib/alephant/broker/response/base.rb
+++ b/lib/alephant/broker/response/base.rb
@@ -21,6 +21,7 @@ module Alephant
         def initialize(status = 200, content_type = "text/html")
           @content = STATUS_CODE_MAPPING[status]
           @headers = { "Content-Type" => content_type }
+          @headers.merge!(Broker.config[:headers]) if Broker.config.has_key?(:headers)
           @status  = status
 
           log_status

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -69,7 +69,7 @@ describe Alephant::Broker::LoadStrategy::HTTP do
         specify do
           expect do
             subject.load component_meta
-          end.to raise_error
+          end.to raise_error(RuntimeError)
         end
       end
 
@@ -83,7 +83,7 @@ describe Alephant::Broker::LoadStrategy::HTTP do
         specify do
           expect do
             subject.load component_meta
-          end.to raise_error
+          end.to raise_error(Alephant::Broker::Errors::ContentNotFound)
         end
       end
     end


### PR DESCRIPTION
Add headers through config to the broker.

_Also fixes the error warning when running the specs._

Depended on with: https://github.com/BBC-News/election-2016-broker/pull/3

https://jira.dev.bbc.co.uk/browse/CONNPOL-2818

![](https://media.giphy.com/media/GYx3rLjdBPfyM/giphy.gif)