### PR TITLE
Fix cache headers being applied to all responses

### DIFF
--- a/lib/alephant/broker/response/base.rb
+++ b/lib/alephant/broker/response/base.rb
@@ -35,7 +35,7 @@ module Alephant
         private
 
         def log_status
-          add_no_cache_headers if status !~ /200/
+          add_no_cache_headers if status != 200
         end
 
         def add_no_cache_headers

--- a/lib/alephant/broker/response/base.rb
+++ b/lib/alephant/broker/response/base.rb
@@ -24,7 +24,7 @@ module Alephant
           @headers.merge!(Broker.config[:headers]) if Broker.config.has_key?(:headers)
           @status  = status
 
-          log_status
+          add_no_cache_headers if status != 200
           setup
         end
 
@@ -33,10 +33,6 @@ module Alephant
         def setup; end
 
         private
-
-        def log_status
-          add_no_cache_headers if status != 200
-        end
 
         def add_no_cache_headers
           headers.merge!(

--- a/spec/integration/rack_spec.rb
+++ b/spec/integration/rack_spec.rb
@@ -74,8 +74,8 @@ describe Alephant::Broker::Application do
       specify { expect(last_response.status).to eql 200 }
       specify { expect(last_response.body).to eql "Test" }
       specify { expect(last_response.headers).to_not include("Cache-Control") }
-    specify { expect(last_response.headers).to_not include("Pragma") }
-    specify { expect(last_response.headers).to_not include("Expires") }
+      specify { expect(last_response.headers).to_not include("Pragma") }
+      specify { expect(last_response.headers).to_not include("Expires") }
     end
 
     context "for valid URL parameters in request" do

--- a/spec/integration/rack_spec.rb
+++ b/spec/integration/rack_spec.rb
@@ -73,6 +73,9 @@ describe Alephant::Broker::Application do
     context "for a valid component ID" do
       specify { expect(last_response.status).to eql 200 }
       specify { expect(last_response.body).to eql "Test" }
+      specify { expect(last_response.headers).to_not include("Cache-Control") }
+    specify { expect(last_response.headers).to_not include("Pragma") }
+    specify { expect(last_response.headers).to_not include("Expires") }
     end
 
     context "for valid URL parameters in request" do


### PR DESCRIPTION
When curling a component, I got no-cache headers even though I received a 200 response.

```
curl -I https://broker.bbc.co.uk/component/council_editorial_text
HTTP/1.1 200 OK
Date: Thu, 11 Feb 2016 20:06:54 GMT
Content-Type: text/html; charset=UTF-8
Access-Control-Allow-Origin: *.bbc.co.uk
Cache-Control: no-cache, must-revalidate
Pragma: no-cache
Expires: Wed, 11 Feb 2015 00:00:00 GMT
X-Sequence: 5010
X-Cache-Version: 1
X-Cached: true
Content-Length: 230
```

Looking at the code, the no cache headers should only be applied with a non-200 response.
```
add_no_cache_headers if status !~ /200/
```

The above exclamation mark and tilde mean that true is returned if status is a 200. I added a test to make sure this was the case, as it failed, then changed the logic to fix this.

https://jira.dev.bbc.co.uk/browse/CONNPOL-3076

![](https://media.giphy.com/media/13sozYO4hmSMUw/giphy.gif)