### PR TITLE
Re-enable broker response code metrics.  Add metric for batch requests

### DIFF
--- a/lib/alephant/broker/response/asset.rb
+++ b/lib/alephant/broker/response/asset.rb
@@ -29,6 +29,7 @@ module Alephant
         end
 
         def log
+          logger.metric "BrokerResponse#{status}"
           logger.info "Broker: Component loaded! #{details} (200)"
         end
       end

--- a/lib/alephant/broker/response/base.rb
+++ b/lib/alephant/broker/response/base.rb
@@ -43,6 +43,10 @@ module Alephant
           log
         end
 
+        def log		
+          logger.metric "BrokerNon200Response#{status}"		
+        end
+
       end
     end
   end

--- a/lib/alephant/broker/response/base.rb
+++ b/lib/alephant/broker/response/base.rb
@@ -43,9 +43,9 @@ module Alephant
           log
         end
 
-        def log		
-          logger.metric "BrokerNon200Response#{status}"		
-        end
+        def log
+          logger.metric "BrokerNon200Response#{status}"
+        en
 
       end
     end

--- a/lib/alephant/broker/response/base.rb
+++ b/lib/alephant/broker/response/base.rb
@@ -45,7 +45,7 @@ module Alephant
 
         def log
           logger.metric "BrokerNon200Response#{status}"
-        en
+        end
 
       end
     end

--- a/lib/alephant/broker/response/base.rb
+++ b/lib/alephant/broker/response/base.rb
@@ -43,9 +43,6 @@ module Alephant
           log
         end
 
-        def log
-          logger.metric "BrokerResponse#{status}"
-        end
       end
     end
   end

--- a/lib/alephant/broker/response/batch.rb
+++ b/lib/alephant/broker/response/batch.rb
@@ -34,7 +34,10 @@ module Alephant
               'content_type' => component.content_type,
               'body'         => component.content
             }
-          end.tap { logger.info "Broker: Batch load done (#{batch_id})" }
+          end.tap { 
+            logger.info "Broker: Batch load done (#{batch_id})" 
+            logger.metric "BrokerBatchLoadCount"
+          }
         end
 
       end


### PR DESCRIPTION

Broker metrics for HTTP response codes haven't worked for a while, and were effectively removed in alephant-broker 3.6.1

Newsbeat-broker records a flat line for response code metrics, regardless of code
AMP and Elections send no response metrics.

There are other issues with metrics (S3InvalidCacheKey means couldn't find the key in S3, for example, it is not related to the cache.rb Elasticache stuff and the key was not invalid).  But I'd like to get this fix in to AMP before launch, so restricting changes looking for quick :cake: 