### PR TITLE
Remove hardcoded status in log

### DIFF
--- a/lib/alephant/broker/response/asset.rb
+++ b/lib/alephant/broker/response/asset.rb
@@ -30,7 +30,7 @@ module Alephant
 
         def log
           logger.metric "BrokerResponse#{status}"
-          logger.info "Broker: Component loaded! #{details} (200)"
+          logger.info "Broker: Component loaded! #{details} (#{status})"
         end
       end
     end


### PR DESCRIPTION
## Problem

When testing our CloudWatch logging, we noticed an invalid url will still log a "Broker component loaded" string along with a 200, and send a 404 metric to CloudWatch.

This seems inconsistent, and a mixed response, of a success and a non-success.

```
WARN [Election2016Broker] - Broker.ComponentFactory.create: Exception raised (ContentNotFound) for foo/7e0c33c476b1089500d5f172102ec03e
W, [2016-02-26T19:09:45.853000 #1261]  WARN -- : Broker.ComponentFactory.create: Exception raised (ContentNotFound) for foo/7e0c33c476b1089500d5f172102ec03e
INFO [Election2016Broker] - Broker: Component loaded! foo/{}/{"Content-Type"=>"text/plain"}  {} (200)
I, [2016-02-26T19:09:45.980000 #1261]  INFO -- : Broker: Component loaded! foo/{}/{"Content-Type"=>"text/plain"}  {} (200)
```

## Solution

I have changed the 200 to `#{status}`, but I am not sure the message makes sense. The ComponentMeta object has been loaded, but the Component wasn't found. I could only log that line if the code is a 200, or change the message.

![](https://media.giphy.com/media/3oJpyi7wBpo0sV9V9C/giphy.gif)