### PR TITLE
Bring in Storage gem

### DIFF
--- a/alephant-broker.gemspec
+++ b/alephant-broker.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rack-test"
 
   spec.add_runtime_dependency "alephant-lookup"
-  spec.add_runtime_dependency "alephant-cache"
+  spec.add_runtime_dependency "alephant-storage"
   spec.add_runtime_dependency "alephant-logger", "1.2.0"
   spec.add_runtime_dependency 'alephant-sequencer'
   spec.add_runtime_dependency "dalli-elasticache"

--- a/lib/alephant/broker/component.rb
+++ b/lib/alephant/broker/component.rb
@@ -1,5 +1,5 @@
 require "crimp"
-require "alephant/cache"
+require "alephant/storage"
 require "alephant/lookup"
 require "alephant/broker/errors/invalid_cache_key"
 require "alephant/sequencer"

--- a/lib/alephant/broker/load_strategy/http.rb
+++ b/lib/alephant/broker/load_strategy/http.rb
@@ -20,7 +20,7 @@ module Alephant
         end
 
         def load(component_meta)
-          cache_object(component_meta)
+          fetch_object(component_meta)
         rescue
           logger.metric "CacheMiss"
           cache.set(component_meta.cache_key, content(component_meta))
@@ -34,7 +34,7 @@ module Alephant
           @cache ||= Cache::Client.new
         end
 
-        def cache_object(component_meta)
+        def fetch_object(component_meta)
           cache.get(component_meta.cache_key) { content component_meta }
         end
 

--- a/lib/alephant/broker/load_strategy/s3/base.rb
+++ b/lib/alephant/broker/load_strategy/s3/base.rb
@@ -17,14 +17,14 @@ module Alephant
 
           def load(component_meta)
             add_s3_headers(
-              cache_object(component_meta),
+              fetch_object(component_meta),
               component_meta
             )
           rescue
             logger.metric "S3CacheMiss"
             add_s3_headers(
               cache.set(
-                cache_key(component_meta),
+                storage_key(component_meta),
                 retrieve_object(component_meta)
               ),
               component_meta
@@ -37,7 +37,7 @@ module Alephant
             Hash.new
           end
 
-          def cache_key(component_meta)
+          def storage_key(component_meta)
             component_meta.component_key
           end
 
@@ -65,14 +65,14 @@ module Alephant
             raise Alephant::Broker::Errors::ContentNotFound
           end
 
-          def cache_object(component_meta)
-            cache.get cache_key(component_meta) do
+          def fetch_object(component_meta)
+            cache.get storage_key(component_meta) do
               retrieve_object component_meta
             end
           end
 
           def s3
-            @s3 ||= Alephant::Cache.new(
+            @s3 ||= Alephant::Storage.new(
               Broker.config[:s3_bucket_id],
               Broker.config[:s3_object_path]
             )

--- a/lib/alephant/broker/load_strategy/s3/sequenced.rb
+++ b/lib/alephant/broker/load_strategy/s3/sequenced.rb
@@ -15,7 +15,7 @@ module Alephant
               component_meta.options,
               sequence(component_meta)
             ).tap do |obj|
-              fail InvalidCacheKey if obj.location.nil?
+              fail InvalidStorageKey if obj.location.nil?
             end.location unless sequence(component_meta).nil?
           end
 
@@ -26,7 +26,7 @@ module Alephant
             )
           end
 
-          def cache_key(component_meta)
+          def storage_key(component_meta)
             "#{super(component_meta)}/#{sequence(component_meta)}"
           end
 

--- a/spec/integration/rack_spec.rb
+++ b/spec/integration/rack_spec.rb
@@ -40,7 +40,7 @@ describe Alephant::Broker::Application do
     )
   end
 
-  let(:s3_cache_double) { instance_double("Alephant::Cache", :get => content) }
+  let(:s3_double) { instance_double("Alephant::Storage", :get => content) }
 
   before do
     allow_any_instance_of(Logger).to receive(:info)
@@ -66,7 +66,7 @@ describe Alephant::Broker::Application do
 
   describe "Component endpoint '/component/...'" do
     before do
-      allow(Alephant::Cache).to receive(:new) { s3_cache_double }
+      allow(Alephant::Storage).to receive(:new) { s3_double }
       get "/component/test_component"
     end
 
@@ -95,7 +95,7 @@ describe Alephant::Broker::Application do
     end
 
     before do
-      allow(Alephant::Cache).to receive(:new) { s3_cache_double }
+      allow(Alephant::Storage).to receive(:new) { s3_double }
     end
 
     context "when using valid batch asset data" do
@@ -115,9 +115,9 @@ describe Alephant::Broker::Application do
         :meta    => {}
       )
     end
-    let(:s3_cache_double) do
+    let(:s3_double) do
       instance_double(
-        "Alephant::Cache",
+        "Alephant::Storage",
         :get => content
       )
     end
@@ -125,7 +125,7 @@ describe Alephant::Broker::Application do
     context "with 404 status code set" do
       before do
         content[:meta]["status"] = 404
-        allow(Alephant::Cache).to receive(:new) { s3_cache_double }
+        allow(Alephant::Storage).to receive(:new) { s3_double }
         get "/component/test_component"
       end
 
@@ -140,7 +140,7 @@ describe Alephant::Broker::Application do
           "head_header_without_dash" => "bar",
           "status"                   => 200
         }
-        allow(Alephant::Cache).to receive(:new) { s3_cache_double }
+        allow(Alephant::Storage).to receive(:new) { s3_double }
         get "/component/test_component"
       end
 
@@ -184,9 +184,9 @@ describe Alephant::Broker::Application do
         :get => "<p>Some data</p>"
       )
     end
-    let(:s3_cache_double) do
+    let(:s3_double) do
       instance_double(
-        "Alephant::Cache",
+        "Alephant::Storage",
         :get => "test_content"
       )
     end
@@ -194,7 +194,7 @@ describe Alephant::Broker::Application do
     context "which is old" do
       before do
         allow(Alephant::Broker::Cache::Client).to receive(:new) { cache_double }
-        allow(Alephant::Cache).to receive(:new) { s3_cache_double }
+        allow(Alephant::Storage).to receive(:new) { s3_double }
       end
       it "should update the cache (call `.set`)" do
         expect(cache_double).to receive(:set).once


### PR DESCRIPTION
This is the other place the Cache gem gets used. I've changed this to use Storage. This means we can deprecate the Alephant Cache gem.

![](https://media.giphy.com/media/p1aqyY6Y0g9uo/giphy.gif)