### PR TITLE
Pass in broker config in hash form

### DIFF
--- a/lib/alephant/broker/load_strategy/s3/sequenced.rb
+++ b/lib/alephant/broker/load_strategy/s3/sequenced.rb
@@ -22,7 +22,9 @@ module Alephant
           def sequencer
             @sequencer ||= Alephant::Sequencer.create(
               Broker.config[:sequencer_table_name],
-              Broker.config
+              {
+                :config => Broker.config
+              }
             )
           end
 


### PR DESCRIPTION
The Sequencer expects the config in a hash.

```ruby
{
  :config => config
}
```

This PR produced the config in the correct format.

https://jira.dev.bbc.co.uk/browse/CONNPOL-2821

![](https://media.giphy.com/media/wTsRdqvBcAccE/giphy.gif)