### PR TITLE
Add Last Modified and ETag headers to batch component response

### DIFF
--- a/alephant-broker.gemspec
+++ b/alephant-broker.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rack-test"
 
   spec.add_runtime_dependency "alephant-lookup"
-  spec.add_runtime_dependency "alephant-storage"
+  spec.add_runtime_dependency "alephant-storage", ">= 1.1.0"
   spec.add_runtime_dependency "alephant-logger", "1.2.0"
   spec.add_runtime_dependency 'alephant-sequencer'
   spec.add_runtime_dependency "dalli-elasticache"

--- a/lib/alephant/broker/component.rb
+++ b/lib/alephant/broker/component.rb
@@ -51,7 +51,10 @@ module Alephant
       end
 
       def header_key(key)
-        key.gsub(HEADER_PREFIX, "").split("-").map(&:capitalize).join("-")
+        key = key.gsub(HEADER_PREFIX, "")
+        return key if key == "ETag"
+
+        key.split("-").map(&:capitalize).join("-")
       end
 
       def symbolize(hash)

--- a/lib/alephant/broker/response/batch.rb
+++ b/lib/alephant/broker/response/batch.rb
@@ -52,15 +52,15 @@ module Alephant
 
         def batch_response_etag
           etags = components.map do |component|
-            component.headers["ETag"] if component.headers["ETag"]
-          end
+            component.headers["ETag"]
+          end.compact
 
           Crimp.signature(etags)
         end
 
         def batch_response_last_modified
           last_modifieds  = components.map do |component|
-            component.headers["Last-Modified"] if component.headers["Last-Modified"]
+            component.headers["Last-Modified"]
           end.compact
 
           last_modifieds.max

--- a/spec/integration/rack_spec.rb
+++ b/spec/integration/rack_spec.rb
@@ -105,6 +105,14 @@ describe Alephant::Broker::Application do
 
       specify { expect(last_response.status).to eql 200 }
       specify { expect(last_response.body).to eq batch_compiled_json }
+      specify {
+        expect(last_response.headers).to eq({
+          "Content-Type"   => "application/json",
+          "ETag"           => "44eaafebcdd94ddac4c4f07ecf0cc80f",
+          "Last-Modified"  => nil,
+          "Content-Length" => "266"
+        })
+      }
     end
   end
 

--- a/spec/integration/rack_spec.rb
+++ b/spec/integration/rack_spec.rb
@@ -100,12 +100,25 @@ describe Alephant::Broker::Application do
     end
 
     before do
+      allow(s3_double).to receive(:get).and_return(
+        content,
+        AWS::Core::Data.new(
+          :content_type => "test/content",
+          :content      => "Test",
+          :meta         => {
+            "head_ETag" => "abc",
+            "head_Last-Modified" => "Mon, 11 Apr 2016 09:39:57 GMT"
+          }
+        )
+      )
+
       allow(Alephant::Storage).to receive(:new) { s3_double }
     end
 
     context "when using valid batch asset data" do
       let(:path) { "/components/batch" }
       let(:content_type) { "application/json" }
+
       before { post path, batch_json, "CONTENT_TYPE" => content_type }
 
       specify { expect(last_response.status).to eql 200 }
@@ -113,7 +126,7 @@ describe Alephant::Broker::Application do
       specify {
         expect(last_response.headers).to eq({
           "Content-Type"   => "application/json",
-          "ETag"           => "685f7ccf4a31c7c150d396df1baa3de7",
+          "ETag"           => "34774567db979628363e6e865127623f",
           "Last-Modified"  => "Mon, 11 Apr 2016 10:39:57 GMT",
           "Content-Length" => "266"
         })

--- a/spec/integration/rack_spec.rb
+++ b/spec/integration/rack_spec.rb
@@ -108,7 +108,7 @@ describe Alephant::Broker::Application do
       specify {
         expect(last_response.headers).to eq({
           "Content-Type"   => "application/json",
-          "ETag"           => "44eaafebcdd94ddac4c4f07ecf0cc80f",
+          "ETag"           => "7e0c33c476b1089500d5f172102ec03e",
           "Last-Modified"  => nil,
           "Content-Length" => "266"
         })

--- a/spec/integration/rack_spec.rb
+++ b/spec/integration/rack_spec.rb
@@ -20,7 +20,10 @@ describe Alephant::Broker::Application do
     AWS::Core::Data.new(
       :content_type => "test/content",
       :content      => "Test",
-      :meta         => {}
+      :meta         => {
+        "head_ETag" => "123",
+        "head_Last-Modified" => "Mon, 11 Apr 2016 10:39:57 GMT"
+      }
     )
   end
   let(:sequencer_double) do
@@ -76,6 +79,8 @@ describe Alephant::Broker::Application do
       specify { expect(last_response.headers).to_not include("Cache-Control") }
       specify { expect(last_response.headers).to_not include("Pragma") }
       specify { expect(last_response.headers).to_not include("Expires") }
+      specify { expect(last_response.headers["ETag"]).to eq("123") }
+      specify { expect(last_response.headers["Last-Modified"]).to eq("Mon, 11 Apr 2016 10:39:57 GMT") }
     end
 
     context "for valid URL parameters in request" do
@@ -108,8 +113,8 @@ describe Alephant::Broker::Application do
       specify {
         expect(last_response.headers).to eq({
           "Content-Type"   => "application/json",
-          "ETag"           => "7e0c33c476b1089500d5f172102ec03e",
-          "Last-Modified"  => nil,
+          "ETag"           => "685f7ccf4a31c7c150d396df1baa3de7",
+          "Last-Modified"  => "Mon, 11 Apr 2016 10:39:57 GMT",
           "Content-Length" => "266"
         })
       }

--- a/spec/integration/rack_spec.rb
+++ b/spec/integration/rack_spec.rb
@@ -123,14 +123,21 @@ describe Alephant::Broker::Application do
 
       specify { expect(last_response.status).to eql 200 }
       specify { expect(last_response.body).to eq batch_compiled_json }
-      specify {
-        expect(last_response.headers).to eq({
-          "Content-Type"   => "application/json",
-          "ETag"           => "34774567db979628363e6e865127623f",
-          "Last-Modified"  => "Mon, 11 Apr 2016 10:39:57 GMT",
-          "Content-Length" => "266"
-        })
-      }
+
+      describe "response should have headers" do
+        it "should have content headers" do
+          expect(last_response.headers["Content-Type"]).to eq("application/json")
+          expect(last_response.headers["Content-Length"]).to eq("266")
+        end
+
+        it "should have ETag cache header" do
+          expect(last_response.headers["ETag"]).to eq("34774567db979628363e6e865127623f")
+        end
+
+        it "should have most recent Last-Modified header" do
+          expect(last_response.headers["Last-Modified"]).to eq("Mon, 11 Apr 2016 10:39:57 GMT")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
The S3 API and Alephant Storage handles the Last Modified and ETag headers for single components, with the prefix of "head_".

This PR adds the functionality to batch responses.

For ETag, I generat a new ETag using crimp, of the fetched component ETags.

For the Last Modified, I take the most recent last modified header.

https://jira.dev.bbc.co.uk/browse/CONNPOL-3135

![](https://media.giphy.com/media/14bhmZtBNhVnIk/giphy.gif)