### PR TITLE
Use patched version of Alephant Storage to parse the DateTime object as a string

### DIFF
--- a/alephant-broker.gemspec
+++ b/alephant-broker.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rack-test"
 
   spec.add_runtime_dependency "alephant-lookup"
-  spec.add_runtime_dependency "alephant-storage", ">= 1.1.0"
+  spec.add_runtime_dependency "alephant-storage", ">= 1.1.1"
   spec.add_runtime_dependency "alephant-logger", "1.2.0"
   spec.add_runtime_dependency 'alephant-sequencer'
   spec.add_runtime_dependency "dalli-elasticache"


### PR DESCRIPTION
Use patched version of Alephant Storage to parse the DateTime object as a string

![](https://media.giphy.com/media/xT0BKm2ePVMjaUFt3q/giphy.gif)