### PR TITLE
Convert header key to string before calling start_with and gsub

### DIFF
--- a/lib/alephant/broker/component.rb
+++ b/lib/alephant/broker/component.rb
@@ -45,7 +45,7 @@ module Alephant
       def meta_data_headers
         @meta_data_headers ||= data[:meta].to_h.reduce({}) do |accum, (k, v)|
           accum.tap do |a|
-            a[header_key(k)] = v.to_s if k.start_with?(HEADER_PREFIX)
+            a[header_key(k.to_s)] = v.to_s if k.to_s.start_with?(HEADER_PREFIX)
           end
         end
       end

--- a/spec/integration/rack_spec.rb
+++ b/spec/integration/rack_spec.rb
@@ -21,8 +21,8 @@ describe Alephant::Broker::Application do
       :content_type => "test/content",
       :content      => "Test",
       :meta         => {
-        "head_ETag" => "123",
-        "head_Last-Modified" => "Mon, 11 Apr 2016 10:39:57 GMT"
+        :head_ETag            => "123",
+        :"head_Last-Modified" => "Mon, 11 Apr 2016 10:39:57 GMT"
       }
     )
   end
@@ -106,8 +106,8 @@ describe Alephant::Broker::Application do
           :content_type => "test/content",
           :content      => "Test",
           :meta         => {
-            "head_ETag" => "abc",
-            "head_Last-Modified" => "Mon, 11 Apr 2016 09:39:57 GMT"
+            :head_ETag            => "abc",
+            :"head_Last-Modified" => "Mon, 11 Apr 2016 09:39:57 GMT"
           }
         )
       )


### PR DESCRIPTION
Convert header key to string before calling start_with and gsub

```
2016-04-14 12:15:13 +0000: Rack app error: #<NoMethodError: undefined method `start_with?' for :head_ETag:Symbol>
/app/.gems/gems/alephant-broker-3.9.1/lib/alephant/broker/component.rb:48:in `meta_data_headers'
```
![](https://media.giphy.com/media/5O3k4fxKARpVS/giphy.gif)