### PR TITLE
Update ETag quote logic and check headers passed in

### DIFF
--- a/lib/alephant/broker/request/batch.rb
+++ b/lib/alephant/broker/request/batch.rb
@@ -10,9 +10,9 @@ module Alephant
         attr_reader :batch_id, :components, :load_strategy
 
         def initialize(component_factory, env)
-          logger.info "Request::Batch#initialize: id: #{env.data['batch_id']}"
+          logger.info "Request::Batch#initialize: id: #{env.data['batch_id']}" if env.data
 
-          @batch_id          = env.data["batch_id"]
+          @batch_id          = env.data["batch_id"] if env.data
           @component_factory = component_factory
           @components        = components_for env
         end
@@ -20,7 +20,7 @@ module Alephant
         private
 
         def components_for(env)
-          env.data["components"].map do |c|
+          ((env.data || {}).fetch("components", []) || []).map do |c|
             @component_factory.create(
               c["component"],
               batch_id,

--- a/lib/alephant/broker/response/asset.rb
+++ b/lib/alephant/broker/response/asset.rb
@@ -9,7 +9,7 @@ module Alephant
         def initialize(component, request_env)
           @component = component
 
-          @status = Alephant::Broker::Response::Base.component_not_modified(@component.headers, request_env) ? NOT_MODIFIED_STATUS_CODE : component.status
+          @status = self.class.component_not_modified(@component.headers, request_env) ? NOT_MODIFIED_STATUS_CODE : component.status
 
           super @status
 

--- a/lib/alephant/broker/response/asset.rb
+++ b/lib/alephant/broker/response/asset.rb
@@ -9,7 +9,7 @@ module Alephant
         def initialize(component, request_env)
           @component = component
 
-          @status = component_not_modified(@component.headers, request_env) ? NOT_MODIFIED_STATUS_CODE : component.status
+          @status = Alephant::Broker::Response::Base.component_not_modified(@component.headers, request_env) ? NOT_MODIFIED_STATUS_CODE : component.status
 
           super @status
 

--- a/lib/alephant/broker/response/asset.rb
+++ b/lib/alephant/broker/response/asset.rb
@@ -9,7 +9,7 @@ module Alephant
         def initialize(component, request_env)
           @component = component
 
-          @status = component_not_modified(@component.headers, request_env) ? 304 : component.status
+          @status = component_not_modified(@component.headers, request_env) ? NOT_MODIFIED_STATUS_CODE : component.status
 
           super @status
 

--- a/lib/alephant/broker/response/base.rb
+++ b/lib/alephant/broker/response/base.rb
@@ -49,9 +49,14 @@ module Alephant
         end
 
         def component_not_modified(headers, request_env)
-          return false if headers["Last-Modified"].nil? && headers["ETag"].nil?
+          return false if request_env.if_modified_since.nil? && request_env.if_none_match.nil?
 
-          headers["Last-Modified"] == request_env.if_modified_since || headers["ETag"] == request_env.if_none_match
+          !request_env.if_modified_since.nil? && headers["Last-Modified"] == request_env.if_modified_since ||
+            !request_env.if_none_match.nil? && unquote_etag(headers["ETag"]) == unquote_etag(request_env.if_none_match)
+        end
+
+        def unquote_etag(etag)
+          etag.to_s.gsub(/\A"|"\Z/, '')
         end
 
         def log

--- a/lib/alephant/broker/response/base.rb
+++ b/lib/alephant/broker/response/base.rb
@@ -21,11 +21,15 @@ module Alephant
 
         def initialize(status = 200, content_type = "text/html")
           @content = STATUS_CODE_MAPPING[status]
-          @headers = { "Content-Type" => content_type }
-          @headers.merge!(Broker.config[:headers]) if Broker.config.has_key?(:headers)
+          @headers = {
+            "Content-Type"                  => content_type,
+            "Access-Control-Allow-Headers"  => "If-None-Match"
+          }
+          headers.merge!(Broker.config[:headers]) if Broker.config.has_key?(:headers)
           @status  = status
 
           add_no_cache_headers if should_add_no_cache_headers?(status)
+          add_etag_allow_header if headers.has_key?(:ETag)
           setup if status == 200
         end
 
@@ -46,6 +50,10 @@ module Alephant
             "Expires"       => Date.today.prev_year.httpdate
           )
           log
+        end
+
+        def add_etag_allow_header
+          headers.merge!("Access-Control-Expose-Headers" => "ETag")
         end
 
         def component_not_modified(headers, request_env)

--- a/lib/alephant/broker/response/base.rb
+++ b/lib/alephant/broker/response/base.rb
@@ -61,16 +61,17 @@ module Alephant
           })
         end
 
-        def component_not_modified(headers, request_env)
+        def self.component_not_modified(headers, request_env)
           return false if request_env.if_modified_since.nil? && request_env.if_none_match.nil?
 
           last_modified_match = !request_env.if_modified_since.nil? && headers["Last-Modified"] == request_env.if_modified_since
-          etag_match          = !request_env.if_none_match.nil? && unquote_etag(headers["ETag"]) == unquote_etag(request_env.if_none_match)
+          etag_match          = !request_env.if_none_match.nil? &&
+            Alephant::Broker::Response::Base.unquote_etag(headers["ETag"]) == Alephant::Broker::Response::Base.unquote_etag(request_env.if_none_match)
 
           last_modified_match || etag_match
         end
 
-        def unquote_etag(etag)
+        def self.unquote_etag(etag)
           etag.to_s.gsub(/\A"|"\Z/, '')
         end
 

--- a/lib/alephant/broker/response/base.rb
+++ b/lib/alephant/broker/response/base.rb
@@ -54,8 +54,10 @@ module Alephant
         def component_not_modified(headers, request_env)
           return false if request_env.if_modified_since.nil? && request_env.if_none_match.nil?
 
-          !request_env.if_modified_since.nil? && headers["Last-Modified"] == request_env.if_modified_since ||
-            !request_env.if_none_match.nil? && unquote_etag(headers["ETag"]) == unquote_etag(request_env.if_none_match)
+          last_modified_match = !request_env.if_modified_since.nil? && headers["Last-Modified"] == request_env.if_modified_since
+          etag_match          = !request_env.if_none_match.nil? && unquote_etag(headers["ETag"]) == unquote_etag(request_env.if_none_match)
+
+          last_modified_match || etag_match
         end
 
         def unquote_etag(etag)

--- a/lib/alephant/broker/response/base.rb
+++ b/lib/alephant/broker/response/base.rb
@@ -29,7 +29,6 @@ module Alephant
           @status  = status
 
           add_no_cache_headers if should_add_no_cache_headers?(status)
-          add_etag_allow_header if headers.has_key?(:ETag)
           setup if status == 200
         end
 
@@ -50,10 +49,6 @@ module Alephant
             "Expires"       => Date.today.prev_year.httpdate
           )
           log
-        end
-
-        def add_etag_allow_header
-          headers.merge!("Access-Control-Expose-Headers" => "ETag")
         end
 
         def component_not_modified(headers, request_env)

--- a/lib/alephant/broker/response/base.rb
+++ b/lib/alephant/broker/response/base.rb
@@ -12,14 +12,14 @@ module Alephant
 
         attr_reader :content, :headers, :status
 
-        STATUS_CODE_MAPPING = {
-          200 => "ok",
-          202 => "",
-          404 => "Not found",
-          500 => "Error retrieving content"
-        }
-
         NOT_MODIFIED_STATUS_CODE = 202
+
+        STATUS_CODE_MAPPING = {
+          200                      => "ok",
+          NOT_MODIFIED_STATUS_CODE => "",
+          404                      => "Not found",
+          500                      => "Error retrieving content"
+        }
 
         def initialize(status = 200, content_type = "text/html")
           @content = STATUS_CODE_MAPPING[status]
@@ -66,7 +66,7 @@ module Alephant
 
           last_modified_match = !request_env.if_modified_since.nil? && headers["Last-Modified"] == request_env.if_modified_since
           etag_match          = !request_env.if_none_match.nil? &&
-            Alephant::Broker::Response::Base.unquote_etag(headers["ETag"]) == Alephant::Broker::Response::Base.unquote_etag(request_env.if_none_match)
+            unquote_etag(headers["ETag"]) == unquote_etag(request_env.if_none_match)
 
           last_modified_match || etag_match
         end

--- a/lib/alephant/broker/response/batch.rb
+++ b/lib/alephant/broker/response/batch.rb
@@ -12,7 +12,7 @@ module Alephant
         def initialize(components, batch_id, request_env)
           @components = components
           @batch_id   = batch_id
-          @status     = component_not_modified(batch_response_headers, request_env) ? NOT_MODIFIED_STATUS_CODE : 200
+          @status     = Alephant::Broker::Response::Base.component_not_modified(batch_response_headers, request_env) ? NOT_MODIFIED_STATUS_CODE : 200
 
           super(@status, "application/json")
 
@@ -55,7 +55,7 @@ module Alephant
 
         def batch_response_etag
           etags = components.map do |component|
-            unquote_etag(component.headers["ETag"])
+            Alephant::Broker::Response::Base.unquote_etag(component.headers["ETag"])
           end.compact.sort
 
           "\"#{Crimp.signature(etags)}\""

--- a/lib/alephant/broker/response/batch.rb
+++ b/lib/alephant/broker/response/batch.rb
@@ -53,10 +53,10 @@ module Alephant
 
         def batch_response_etag
           etags = components.map do |component|
-            component.headers["ETag"]
+            unquote_etag(component.headers["ETag"])
           end.compact.sort
 
-          Crimp.signature(etags)
+          "\"#{Crimp.signature(etags)}\""
         end
 
         def batch_response_last_modified

--- a/lib/alephant/broker/response/batch.rb
+++ b/lib/alephant/broker/response/batch.rb
@@ -12,7 +12,7 @@ module Alephant
         def initialize(components, batch_id, request_env)
           @components = components
           @batch_id   = batch_id
-          @status     = component_not_modified(batch_response_headers, request_env) ? 304 : 200
+          @status     = component_not_modified(batch_response_headers, request_env) ? NOT_MODIFIED_STATUS_CODE : 200
 
           super(@status, "application/json")
 
@@ -45,6 +45,8 @@ module Alephant
         end
 
         def batch_response_headers
+          return {} unless components.count
+
           {
             "ETag"          => batch_response_etag,
             "Last-Modified" => batch_response_last_modified

--- a/lib/alephant/broker/response/batch.rb
+++ b/lib/alephant/broker/response/batch.rb
@@ -12,7 +12,7 @@ module Alephant
         def initialize(components, batch_id, request_env)
           @components = components
           @batch_id   = batch_id
-          @status     = Alephant::Broker::Response::Base.component_not_modified(batch_response_headers, request_env) ? NOT_MODIFIED_STATUS_CODE : 200
+          @status     = self.class.component_not_modified(batch_response_headers, request_env) ? NOT_MODIFIED_STATUS_CODE : 200
 
           super(@status, "application/json")
 
@@ -55,7 +55,7 @@ module Alephant
 
         def batch_response_etag
           etags = components.map do |component|
-            Alephant::Broker::Response::Base.unquote_etag(component.headers["ETag"])
+            self.class.unquote_etag(component.headers["ETag"])
           end.compact.sort
 
           "\"#{Crimp.signature(etags)}\""

--- a/spec/integration/rack_spec.rb
+++ b/spec/integration/rack_spec.rb
@@ -49,7 +49,7 @@ describe Alephant::Broker::Application do
 
   let(:s3_double) { instance_double("Alephant::Storage", :get => content) }
 
-  let(:not_modified_status_code) { 202 }
+  let(:not_modified_status_code) { Alephant::Broker::Response::Base::NOT_MODIFIED_STATUS_CODE }
 
   before do
     allow_any_instance_of(Logger).to receive(:info)

--- a/spec/integration/rack_spec.rb
+++ b/spec/integration/rack_spec.rb
@@ -132,7 +132,7 @@ describe Alephant::Broker::Application do
           :content_type => "test/content",
           :content      => "Test",
           :meta         => {
-            :head_ETag            => "abc",
+            :head_ETag            => "\"abc\"",
             :"head_Last-Modified" => "Mon, 11 Apr 2016 09:39:57 GMT"
           }
         )
@@ -157,7 +157,7 @@ describe Alephant::Broker::Application do
         end
 
         it "should have ETag cache header" do
-          expect(last_response.headers["ETag"]).to eq("34774567db979628363e6e865127623f")
+          expect(last_response.headers["ETag"]).to eq('"34774567db979628363e6e865127623f"')
         end
 
         it "should have most recent Last-Modified header" do
@@ -206,7 +206,7 @@ describe Alephant::Broker::Application do
     context "when requesting an unmodified response" do
       let(:path)         { "/components/batch" }
       let(:content_type) { "application/json" }
-      let(:etag)         { "34774567db979628363e6e865127623f" }
+      let(:etag)         { '"34774567db979628363e6e865127623f"' }
 
       before do
         post(path, batch_json,

--- a/spec/integration/rack_spec.rb
+++ b/spec/integration/rack_spec.rb
@@ -49,6 +49,8 @@ describe Alephant::Broker::Application do
 
   let(:s3_double) { instance_double("Alephant::Storage", :get => content) }
 
+  let(:not_modified_status_code) { 202 }
+
   before do
     allow_any_instance_of(Logger).to receive(:info)
     allow_any_instance_of(Logger).to receive(:debug)
@@ -106,7 +108,7 @@ describe Alephant::Broker::Application do
       )
     end
 
-    specify { expect(last_response.status).to eql 304 }
+    specify { expect(last_response.status).to eql not_modified_status_code }
     specify { expect(last_response.body).to eql "" }
     specify { expect(last_response.headers).to_not include("Cache-Control") }
     specify { expect(last_response.headers).to_not include("Pragma") }
@@ -214,12 +216,12 @@ describe Alephant::Broker::Application do
           "HTTP_IF_NONE_MATCH" => etag)
       end
 
-      specify { expect(last_response.status).to eql 304 }
+      specify { expect(last_response.status).to eql not_modified_status_code }
       specify { expect(last_response.body).to eq "" }
 
       describe "response should have headers" do
-        it "should NOT have a Content-Type header" do
-          expect(last_response.headers).to_not include("Content-Type")
+        it "should have a Content-Type header" do
+          expect(last_response.headers).to include("Content-Type")
         end
 
         it "should have ETag cache header" do


### PR DESCRIPTION
Update ETag quote logic and check headers passed in

* Single components were returning an ETag quoted. Batch responses were unquoted.
* This quotes all ETag responses and unquotes them when checking if they are equal
* This checks headers passed in to see if needing a modified response (as a 200 would be returned otherwise (or 404, 5xx if needed)
* This also checks for nil before checking if they are equal, just to only serve a 304 if not nil and they are equal

https://jira.dev.bbc.co.uk/browse/CONNPOL-3135

![](https://media.giphy.com/media/3o6ozsIxg5legYvggo/giphy.gif)