### PR TITLE
Small additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 *.gem
 
 /pkg
+/coverage

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in alephant-broker.gemspec
 gemspec

--- a/Guardfile
+++ b/Guardfile
@@ -1,6 +1,6 @@
-guard 'rspec' do
+guard "rspec" do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/.+\.rb$})
   watch(%r{^spec/support/(.+)\.rb$})                  { "spec" }
-  watch('spec/spec_helper.rb')                        { "spec" }
+  watch("spec/spec_helper.rb")                        { "spec" }
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,8 @@
-$:.unshift File.join(File.dirname(__FILE__), 'lib')
+$LOAD_PATH.unshift File.join(File.dirname(__FILE__), "lib")
 
-require 'rspec/core/rake_task'
-require 'bundler/gem_tasks'
-require 'alephant/broker'
-require 'rake/rspec'
+require "rspec/core/rake_task"
+require "bundler/gem_tasks"
+require "alephant/broker"
+require "rake/rspec"
 
 task :default => :spec

--- a/alephant-broker.gemspec
+++ b/alephant-broker.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rack-test"
+  spec.add_development_dependency "simplecov"
 
   spec.add_runtime_dependency "alephant-lookup"
   spec.add_runtime_dependency "alephant-storage", ">= 1.1.1"

--- a/lib/alephant/broker.rb
+++ b/lib/alephant/broker.rb
@@ -1,11 +1,10 @@
-require 'alephant/broker/version'
-require 'alephant/broker/request'
-require 'alephant/broker/environment'
-require 'alephant/broker'
+require "alephant/broker/version"
+require "alephant/broker/request"
+require "alephant/broker/environment"
+require "alephant/broker"
 
 module Alephant
   module Broker
-
     def self.handle(load_strategy, env)
       Request::Handler.process(load_strategy, env)
     end

--- a/lib/alephant/broker/cache.rb
+++ b/lib/alephant/broker/cache.rb
@@ -1,5 +1,5 @@
-require 'dalli-elasticache'
-require 'alephant/logger'
+require "dalli-elasticache"
+require "alephant/logger"
 
 module Alephant
   module Broker
@@ -7,29 +7,27 @@ module Alephant
       class Client
         include Logger
 
-        DEFAULT_TTL  = 2592000
+        DEFAULT_TTL = 2_592_000
 
         def initialize
-          unless config_endpoint.nil?
-            @elasticache ||= ::Dalli::ElastiCache.new(config_endpoint, { :expires_in => ttl })
-            @client ||= @elasticache.client
-          else
+          if config_endpoint.nil?
             logger.debug "Broker::Cache::Client#initialize: No config endpoint, NullClient used"
             logger.metric "NoConfigEndpoint"
             @client = NullClient.new
+          else
+            @elasticache ||= ::Dalli::ElastiCache.new(config_endpoint, :expires_in => ttl)
+            @client ||= @elasticache.client
           end
         end
 
-        def get(key, &block)
-          begin
-            versioned_key = versioned key
-            result = @client.get versioned_key
-            logger.info "Broker::Cache::Client#get key: #{versioned_key} - #{result ? 'hit' : 'miss'}"
-            logger.metric "GetKeyMiss" unless result
-            result ? result : set(key, block.call)
-          rescue StandardError => e
-            block.call if block_given?
-          end
+        def get(key)
+          versioned_key = versioned key
+          result = @client.get versioned_key
+          logger.info "Broker::Cache::Client#get key: #{versioned_key} - #{result ? 'hit' : 'miss'}"
+          logger.metric "GetKeyMiss" unless result
+          result ? result : set(key, block.call)
+        rescue StandardError => e
+          yield if block_given?
         end
 
         def set(key, value, ttl = nil)
@@ -39,28 +37,28 @@ module Alephant
         private
 
         def config_endpoint
-          Broker.config['elasticache_config_endpoint']
+          Broker.config["elasticache_config_endpoint"]
         end
 
         def ttl
-          Broker.config['elasticache_ttl'] || DEFAULT_TTL
+          Broker.config["elasticache_ttl"] || DEFAULT_TTL
         end
 
         def versioned(key)
-          [key, cache_version].compact.join('_')
+          [key, cache_version].compact.join("_")
         end
 
         def cache_version
-          Broker.config['elasticache_cache_version']
+          Broker.config["elasticache_cache_version"]
         end
       end
 
       class NullClient
-        def get(key, &block)
+        def get(_key)
           yield
         end
 
-        def set(key, value, ttl = nil)
+        def set(_key, value, _ttl = nil)
           value
         end
       end

--- a/lib/alephant/broker/component.rb
+++ b/lib/alephant/broker/component.rb
@@ -10,7 +10,7 @@ module Alephant
     class Component
       attr_reader :id, :batch_id, :options, :content, :opts_hash
 
-      HEADER_PREFIX = "head_"
+      HEADER_PREFIX = "head_".freeze
 
       def initialize(meta, data)
         @id        = meta.id

--- a/lib/alephant/broker/component_factory.rb
+++ b/lib/alephant/broker/component_factory.rb
@@ -1,7 +1,7 @@
-require 'alephant/broker/component_meta'
-require 'alephant/broker/errors/content_not_found'
-require 'alephant/broker/error_component'
-require 'alephant/logger'
+require "alephant/broker/component_meta"
+require "alephant/broker/errors/content_not_found"
+require "alephant/broker/error_component"
+require "alephant/logger"
 
 module Alephant
   module Broker

--- a/lib/alephant/broker/component_meta.rb
+++ b/lib/alephant/broker/component_meta.rb
@@ -24,7 +24,7 @@ module Alephant
       private
 
       def convert_keys(hash)
-        Hash[ hash.map { |k, v| [k.to_sym, v] } ]
+        Hash[hash.map { |k, v| [k.to_sym, v] }]
       end
 
       def renderer_key

--- a/lib/alephant/broker/environment.rb
+++ b/lib/alephant/broker/environment.rb
@@ -1,6 +1,6 @@
-require 'json'
-require 'alephant/logger'
-require 'rack'
+require "json"
+require "alephant/logger"
+require "rack"
 
 module Alephant
   module Broker
@@ -55,17 +55,15 @@ module Alephant
       private
 
       def rack_input
-        (settings["rack.input"].read).tap { settings["rack.input"].rewind }
+        settings["rack.input"].read.tap { settings["rack.input"].rewind }
       end
 
       def parse(json)
-        begin
-          ::JSON.parse(json)
-        rescue ::JSON::ParserError => e
-          logger.warn "Broker.environment#data: ParserError"
-          logger.metric "JSONParserError"
-          nil
-        end
+        ::JSON.parse(json)
+      rescue ::JSON::ParserError => e
+        logger.warn "Broker.environment#data: ParserError"
+        logger.metric "JSONParserError"
+        nil
       end
     end
   end

--- a/lib/alephant/broker/error_component.rb
+++ b/lib/alephant/broker/error_component.rb
@@ -12,25 +12,25 @@ module Alephant
       end
 
       def content_type
-        headers['Content-Type']
+        headers["Content-Type"]
       end
 
       def headers
         {
-          'Content-Type' => 'text/plain'
+          "Content-Type" => "text/plain"
         }
       end
 
       private
 
       def content_for(exception)
-        "#{exception.message}".tap do |msg|
+        exception.message.to_s.tap do |msg|
           msg << "\n#{exception.backtrace.join('\n')}" if debug?
         end
       end
 
       def debug?
-        Broker.config.fetch('debug', false)
+        Broker.config.fetch("debug", false)
       end
     end
   end

--- a/lib/alephant/broker/errors/content_not_found.rb
+++ b/lib/alephant/broker/errors/content_not_found.rb
@@ -3,7 +3,7 @@ module Alephant
     module Errors
       class ContentNotFound < StandardError
         def message
-          'Not Found'
+          "Not Found"
         end
       end
     end

--- a/lib/alephant/broker/errors/invalid_asset_id.rb
+++ b/lib/alephant/broker/errors/invalid_asset_id.rb
@@ -1,11 +1,9 @@
 module Alephant
   module Broker
     class InvalidAssetId < Exception
-
       def initialize(msg)
         super
       end
-
     end
   end
 end

--- a/lib/alephant/broker/errors/invalid_cache_key.rb
+++ b/lib/alephant/broker/errors/invalid_cache_key.rb
@@ -2,7 +2,7 @@ module Alephant
   module Broker
     class InvalidCacheKey < Exception
       def initialize
-        super 'Cache key not found based on component_id and options combination'
+        super "Cache key not found based on component_id and options combination"
       end
     end
   end

--- a/lib/alephant/broker/load_strategy/http.rb
+++ b/lib/alephant/broker/load_strategy/http.rb
@@ -1,7 +1,7 @@
-require 'alephant/broker/cache'
-require 'alephant/broker/errors/content_not_found'
-require 'alephant/logger'
-require 'faraday'
+require "alephant/broker/cache"
+require "alephant/broker/errors/content_not_found"
+require "alephant/logger"
+require "faraday"
 
 module Alephant
   module Broker
@@ -41,20 +41,20 @@ module Alephant
         def content(component_meta)
           resp = request component_meta
           {
-            :content => resp.body,
+            :content      => resp.body,
             :content_type => extract_content_type_from(resp.env.response_headers)
           }
         end
 
         def extract_content_type_from(headers)
-          headers['content-type'].split(';').first
+          headers["content-type"].split(";").first
         end
 
         def request(component_meta)
           before = Time.new
           component_meta.cached = false
 
-          Faraday.get(url_for component_meta).tap do |r|
+          Faraday.get(url_for(component_meta)).tap do |r|
             unless r.success?
               logger.metric "ContentNotFound"
               raise Alephant::Broker::Errors::ContentNotFound
@@ -62,9 +62,8 @@ module Alephant
 
             request_time = Time.new - before
             logger.metric("LoadComponentTime",
-                          :unit  => "Seconds",
-                          :value => request_time
-                         )
+              :unit  => "Seconds",
+              :value => request_time)
           end
         end
 

--- a/lib/alephant/broker/load_strategy/s3/base.rb
+++ b/lib/alephant/broker/load_strategy/s3/base.rb
@@ -33,7 +33,7 @@ module Alephant
 
           protected
 
-          def headers(component_meta)
+          def headers(_component_meta)
             Hash.new
           end
 
@@ -43,8 +43,8 @@ module Alephant
 
           private
 
-          def s3_path(component_meta)
-            fail NotImplementedError
+          def s3_path(_component_meta)
+            raise NotImplementedError
           end
 
           def add_s3_headers(component_data, component_meta)
@@ -85,10 +85,10 @@ module Alephant
             )
           end
 
-          def headers(component_meta)
+          def headers(_component_meta)
             {
-              'X-Cache-Version'    => Broker.config['elasticache_cache_version'].to_s,
-              'X-Cached'           => cached.to_s
+              "X-Cache-Version" => Broker.config["elasticache_cache_version"].to_s,
+              "X-Cached"        => cached.to_s
             }
           end
         end

--- a/lib/alephant/broker/load_strategy/s3/sequenced.rb
+++ b/lib/alephant/broker/load_strategy/s3/sequenced.rb
@@ -15,16 +15,13 @@ module Alephant
               component_meta.options,
               sequence(component_meta)
             ).tap do |obj|
-              fail InvalidCacheKey if obj.location.nil?
+              raise InvalidCacheKey if obj.location.nil?
             end.location unless sequence(component_meta).nil?
           end
 
           def sequencer
             @sequencer ||= Alephant::Sequencer.create(
-              Broker.config[:sequencer_table_name],
-              {
-                :config => Broker.config
-              }
+              Broker.config[:sequencer_table_name], :config => Broker.config
             )
           end
 

--- a/lib/alephant/broker/request.rb
+++ b/lib/alephant/broker/request.rb
@@ -1,10 +1,10 @@
 module Alephant
   module Broker
     module Request
-      require 'alephant/broker/request/asset'
-      require 'alephant/broker/request/batch'
-      require 'alephant/broker/request/factory'
-      require 'alephant/broker/request/handler'
+      require "alephant/broker/request/asset"
+      require "alephant/broker/request/batch"
+      require "alephant/broker/request/factory"
+      require "alephant/broker/request/handler"
 
       class NotFound; end
       class Status; end

--- a/lib/alephant/broker/request/asset.rb
+++ b/lib/alephant/broker/request/asset.rb
@@ -1,5 +1,5 @@
-require 'alephant/logger'
-require 'alephant/broker/errors/invalid_asset_id'
+require "alephant/logger"
+require "alephant/broker/errors/invalid_asset_id"
 
 module Alephant
   module Broker
@@ -24,10 +24,9 @@ module Alephant
         private
 
         def component_id(path)
-          path.split('/')[2] || (raise InvalidAssetId.new 'No Asset ID specified')
+          path.split("/")[2] || (raise InvalidAssetId.new "No Asset ID specified")
         end
       end
     end
   end
 end
-

--- a/lib/alephant/broker/request/batch.rb
+++ b/lib/alephant/broker/request/batch.rb
@@ -10,11 +10,11 @@ module Alephant
         attr_reader :batch_id, :components, :load_strategy
 
         def initialize(component_factory, env)
-          if env.data
-            @batch_id        = env.data["batch_id"]
-          else
-            @batch_id        = env.options.fetch("batch_id", nil)
-          end
+          @batch_id = if env.data
+                        env.data["batch_id"]
+                      else
+                        env.options.fetch("batch_id", nil)
+                      end
 
           logger.info "Request::Batch#initialize: id: #{batch_id}"
 
@@ -45,4 +45,3 @@ module Alephant
     end
   end
 end
-

--- a/lib/alephant/broker/request/factory.rb
+++ b/lib/alephant/broker/request/factory.rb
@@ -1,5 +1,5 @@
-require 'alephant/broker/request'
-require 'alephant/broker/component_factory'
+require "alephant/broker/request"
+require "alephant/broker/component_factory"
 
 module Alephant
   module Broker

--- a/lib/alephant/broker/request/handler.rb
+++ b/lib/alephant/broker/request/handler.rb
@@ -1,10 +1,10 @@
-require 'alephant/logger'
+require "alephant/logger"
 
-require 'alephant/broker/request'
-require 'alephant/broker/response'
-require 'alephant/broker/request/factory'
-require 'alephant/broker/response/factory'
-require 'alephant/broker/errors/content_not_found'
+require "alephant/broker/request"
+require "alephant/broker/response"
+require "alephant/broker/request/factory"
+require "alephant/broker/response/factory"
+require "alephant/broker/errors/content_not_found"
 
 module Alephant
   module Broker
@@ -27,4 +27,3 @@ module Alephant
     end
   end
 end
-

--- a/lib/alephant/broker/response.rb
+++ b/lib/alephant/broker/response.rb
@@ -1,23 +1,28 @@
 module Alephant
   module Broker
     module Response
-      require 'alephant/broker/response/base'
-      require 'alephant/broker/response/asset'
-      require 'alephant/broker/response/batch'
-      require 'alephant/broker/response/factory'
+      require "alephant/broker/response/base"
+      require "alephant/broker/response/asset"
+      require "alephant/broker/response/batch"
+      require "alephant/broker/response/factory"
 
       class NotFound < Base
-        def initialize; super(404) end
+        def initialize
+          super(404)
+        end
       end
 
       class Status < Base
-        def initialize; super(200) end
+        def initialize
+          super(200)
+        end
       end
 
       class ServerError < Base
-        def initialize; super(500) end
+        def initialize
+          super(500)
+        end
       end
     end
   end
 end
-

--- a/lib/alephant/broker/response/asset.rb
+++ b/lib/alephant/broker/response/asset.rb
@@ -1,4 +1,4 @@
-require 'alephant/logger'
+require "alephant/logger"
 
 module Alephant
   module Broker
@@ -17,14 +17,14 @@ module Alephant
         end
 
         def setup
-          @content  = @component.content
+          @content = @component.content
           log if @component.is_a? Component
         end
 
         private
 
         def batched
-          @component.batch_id.nil? ? '' : 'batched'
+          @component.batch_id.nil? ? "" : "batched"
         end
 
         def details
@@ -40,4 +40,3 @@ module Alephant
     end
   end
 end
-

--- a/lib/alephant/broker/response/base.rb
+++ b/lib/alephant/broker/response/base.rb
@@ -19,20 +19,20 @@ module Alephant
           NOT_MODIFIED_STATUS_CODE => "",
           404                      => "Not found",
           500                      => "Error retrieving content"
-        }
+        }.freeze
 
         def initialize(status = 200, content_type = "text/html", request_env = nil)
           @content = STATUS_CODE_MAPPING[status]
           @headers = {
-            "Content-Type"                  => content_type,
-            "Access-Control-Allow-Headers"  => "If-None-Match, If-Modified-Since",
-            "Access-Control-Allow-Origin"   => "*"
+            "Content-Type"                 => content_type,
+            "Access-Control-Allow-Headers" => "If-None-Match, If-Modified-Since",
+            "Access-Control-Allow-Origin"  => "*"
           }
-          headers.merge!(Broker.config[:headers]) if Broker.config.has_key?(:headers)
-          @status  = status
+          headers.merge!(Broker.config[:headers]) if Broker.config.key?(:headers)
+          @status = status
 
           add_no_cache_headers if should_add_no_cache_headers?(status)
-          add_etag_allow_header if headers.has_key?("ETag")
+          add_etag_allow_header if headers.key?("ETag")
           setup if status == 200
 
           @content = "" if self.class.options?(request_env)
@@ -58,9 +58,7 @@ module Alephant
         end
 
         def add_etag_allow_header
-          headers.merge!({
-            "Access-Control-Expose-Headers" => "ETag"
-          })
+          headers.merge!("Access-Control-Expose-Headers" => "ETag")
         end
 
         def self.options?(request_env)
@@ -74,13 +72,13 @@ module Alephant
 
           last_modified_match = !request_env.if_modified_since.nil? && headers["Last-Modified"] == request_env.if_modified_since
           etag_match          = !request_env.if_none_match.nil? &&
-            unquote_etag(headers["ETag"]) == unquote_etag(request_env.if_none_match)
+                                unquote_etag(headers["ETag"]) == unquote_etag(request_env.if_none_match)
 
           last_modified_match || etag_match
         end
 
         def self.unquote_etag(etag)
-          etag.to_s.gsub(/\A"|"\Z/, '')
+          etag.to_s.gsub(/\A"|"\Z/, "")
         end
 
         def self.allow_not_modified_response_status
@@ -90,7 +88,6 @@ module Alephant
         def log
           logger.metric "BrokerNon200Response#{status}"
         end
-
       end
     end
   end

--- a/lib/alephant/broker/response/batch.rb
+++ b/lib/alephant/broker/response/batch.rb
@@ -20,10 +20,8 @@ module Alephant
         end
 
         def setup
-          @content = ::JSON.generate({
-            'batch_id' => batch_id,
-            'components' => json
-          })
+          @content = ::JSON.generate("batch_id"   => batch_id,
+                                     "components" => json)
         end
 
         private
@@ -38,10 +36,10 @@ module Alephant
               "content_type" => component.content_type,
               "body"         => component.content
             }
-          end.tap {
+          end.tap do
             logger.info "Broker: Batch load done (#{batch_id})"
             logger.metric "BrokerBatchLoadCount"
-          }
+          end
         end
 
         def batch_response_headers
@@ -62,7 +60,7 @@ module Alephant
         end
 
         def batch_response_last_modified
-          last_modifieds  = components.map do |component|
+          last_modifieds = components.map do |component|
             component.headers["Last-Modified"]
           end.compact
 

--- a/lib/alephant/broker/response/factory.rb
+++ b/lib/alephant/broker/response/factory.rb
@@ -1,4 +1,4 @@
-require 'alephant/broker/response'
+require "alephant/broker/response"
 
 module Alephant
   module Broker
@@ -28,4 +28,3 @@ module Alephant
     end
   end
 end
-

--- a/lib/alephant/broker/version.rb
+++ b/lib/alephant/broker/version.rb
@@ -1,5 +1,5 @@
 module Alephant
   module Broker
-    VERSION = "3.13.0"
+    VERSION = "3.13.0".freeze
   end
 end

--- a/spec/archive_spec.rb
+++ b/spec/archive_spec.rb
@@ -8,7 +8,7 @@ describe Alephant::Broker::LoadStrategy::S3::Archived do
     let(:component_meta) { double(:id => id) }
 
     specify do
-      expect(subject.s3_path component_meta).to eq id
+      expect(subject.s3_path(component_meta)).to eq id
     end
 
     context "no location associated with component meta" do

--- a/spec/component_meta_spec.rb
+++ b/spec/component_meta_spec.rb
@@ -1,11 +1,11 @@
-require_relative 'spec_helper'
+require_relative "spec_helper"
 
 describe Alephant::Broker::ComponentMeta do
   let(:id) { "foo" }
   let(:batch_id) { "bar" }
   let(:options) do
     {
-      'variant' => 'K03000001'
+      "variant" => "K03000001"
     }
   end
   subject { described_class.new(id, batch_id, options) }

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -5,19 +5,19 @@ describe Alephant::Broker::LoadStrategy::HTTP do
 
   let(:component_meta) do
     double(
-      'Alephant::Broker::ComponentMeta',
-      cache_key: 'cache_key',
-      id: 'test',
-      options: {}
+      "Alephant::Broker::ComponentMeta",
+      :cache_key => "cache_key",
+      :id        => "test",
+      :options   => {}
     )
   end
-  let(:url_generator) { double(generate: "http://foo.bar") }
-  let(:cache) { double('Alephant::Broker::Cache::Client') }
-  let(:body) { '<h1>Batman!</h1>' }
+  let(:url_generator) { double(:generate => "http://foo.bar") }
+  let(:cache) { double("Alephant::Broker::Cache::Client") }
+  let(:body) { "<h1>Batman!</h1>" }
   let(:content) do
     {
-      :content => body,
-      :content_type => 'text/html'
+      :content      => body,
+      :content_type => "text/html"
     }
   end
 
@@ -32,7 +32,7 @@ describe Alephant::Broker::LoadStrategy::HTTP do
       end
 
       it "gets from cache" do
-        expect(subject.load component_meta).to eq content
+        expect(subject.load(component_meta)).to eq content
       end
     end
 
@@ -43,21 +43,22 @@ describe Alephant::Broker::LoadStrategy::HTTP do
       end
 
       context "and available over HTTP" do
-        let(:env) { double('env', response_headers: response_headers) }
-        let(:response_headers) { {'content-type' => 'text/html; test'} }
+        let(:env) { double("env", :response_headers => response_headers) }
+        let(:response_headers) { { "content-type" => "text/html; test" } }
 
         before :each do
           allow(Faraday).to receive(:get) do
             instance_double(
-              'Faraday::Response',
-              body: body,
+              "Faraday::Response",
+              :body       => body,
               :'success?' => true,
-              env: env)
+              :env        => env
+            )
           end
-         end
+        end
 
         it "gets from HTTP" do
-         expect(subject.load component_meta).to eq content
+          expect(subject.load(component_meta)).to eq content
         end
       end
 
@@ -76,7 +77,7 @@ describe Alephant::Broker::LoadStrategy::HTTP do
       context "and HTTP request 404s" do
         before :each do
           allow(Faraday).to receive(:get) do
-            instance_double('Faraday::Response', body: body, :'success?' => false)
+            instance_double("Faraday::Response", :body => body, :'success?' => false)
           end
         end
 

--- a/spec/integration/not_modified_response_spec.rb
+++ b/spec/integration/not_modified_response_spec.rb
@@ -65,9 +65,7 @@ describe Alephant::Broker::Application do
       get(
         "/component/test_component",
         {},
-        {
-          "HTTP_IF_MODIFIED_SINCE" => "Mon, 11 Apr 2016 10:39:57 GMT"
-        }
+        "HTTP_IF_MODIFIED_SINCE" => "Mon, 11 Apr 2016 10:39:57 GMT"
       )
     end
 
@@ -123,7 +121,7 @@ describe Alephant::Broker::Application do
 
       before do
         post(path, batch_json,
-          "CONTENT_TYPE"  => content_type,
+          "CONTENT_TYPE"       => content_type,
           "HTTP_IF_NONE_MATCH" => etag)
       end
 
@@ -196,10 +194,8 @@ describe Alephant::Broker::Application do
         get(
           path,
           {},
-          {
-            "CONTENT_TYPE"  => content_type,
-            "HTTP_IF_NONE_MATCH" => etag
-          }
+          "CONTENT_TYPE"       => content_type,
+          "HTTP_IF_NONE_MATCH" => etag
         )
       end
 

--- a/spec/integration/rack_spec.rb
+++ b/spec/integration/rack_spec.rb
@@ -123,11 +123,11 @@ describe Alephant::Broker::Application do
     end
 
     context "for invalid URL parameters in request" do
-      before {
+      before do
         content[:meta]["status"] = 404
         allow(Alephant::Storage).to receive(:new) { s3_double }
         options "/component/invalid_component"
-      }
+      end
       specify { expect(last_response.status).to eq 404 }
       specify { expect(last_response.body).to eq "" }
       specify { expect(last_response.headers["Content-Type"]).to eq("test/content") }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,23 +1,23 @@
-$: << File.join(File.dirname(__FILE__), '..', 'lib')
+$LOAD_PATH << File.join(File.dirname(__FILE__), "..", "lib")
 
-require 'simplecov'
+require "simplecov"
 
 SimpleCov.start do
-  add_filter '/spec/'
+  add_filter "/spec/"
 end
 
-require 'pry'
-require 'json'
-require 'alephant/broker'
-require 'alephant/broker/load_strategy/s3/sequenced'
-require 'alephant/broker/load_strategy/s3/archived'
+require "pry"
+require "json"
+require "alephant/broker"
+require "alephant/broker/load_strategy/s3/sequenced"
+require "alephant/broker/load_strategy/s3/archived"
 require "alephant/broker/load_strategy/http"
 require "alephant/broker/cache"
 require "alephant/broker/errors/content_not_found"
 
 require "rack/test"
 
-ENV['RACK_ENV'] = "test"
+ENV["RACK_ENV"] = "test"
 
 RSpec.configure do |config|
   config.order = "random"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,11 @@
 $: << File.join(File.dirname(__FILE__), '..', 'lib')
 
+require 'simplecov'
+
+SimpleCov.start do
+  add_filter '/spec/'
+end
+
 require 'pry'
 require 'json'
 require 'alephant/broker'


### PR DESCRIPTION
The first commit in this PR adds `simplecov` to the test suite giving us some code coverage metrics.  I don't tend to get obsessive about coverage, but when picking up a new project it's a good way of telling you where to tread carefully...

Here's a couple of screenshots of it in action both on the shell and the generated HTML report (stored in the generated `/coverage` directory):

![simplecov-shell](https://cloud.githubusercontent.com/assets/49645/15319793/a608ef8e-1c24-11e6-9a5f-689214b0850c.png)

![simplecov-html](https://cloud.githubusercontent.com/assets/49645/15319800/ab8ed84c-1c24-11e6-896c-8064823f3e79.png)

The second commit is the result of running `rubocop -a .` in the root of the repo using the style guidelines defined in https://github.com/BBC-News/rubocop-config.