### PR TITLE
Added revalidating response header

### DIFF
--- a/lib/alephant/broker/load_strategy/revalidate/strategy.rb
+++ b/lib/alephant/broker/load_strategy/revalidate/strategy.rb
@@ -21,6 +21,8 @@ module Alephant
 
             data = loaded_content.to_h
             data.fetch(:meta, {})[:status] = 200
+            add_revalidating_headers(data) if loaded_content.expired?
+
             data
           rescue *STORAGE_ERRORS
             update_content(component_meta)
@@ -57,6 +59,11 @@ module Alephant
                 refresh_content(component_meta)
               end
             end
+          end
+
+          def add_revalidating_headers(data)
+             data[:headers] ||= {}
+             data[:headers]['broker-cache'] = 'revalidating'
           end
 
           def fetch_stored_content(component_meta)

--- a/lib/alephant/broker/version.rb
+++ b/lib/alephant/broker/version.rb
@@ -1,5 +1,5 @@
 module Alephant
   module Broker
-    VERSION = "3.15.2".freeze
+    VERSION = "3.16.0".freeze
   end
 end


### PR DESCRIPTION
To allow us to show an up to date version of a market data chart to a journalist we need to know when the chart they're viewing is stale (and about to be updated).

This PR should add the response header `broker-cache: revalidating`.

We can then use this header to refresh the chart in the MD admin UI.

Related ticket: https://jira.dev.bbc.co.uk/browse/NEWSINDEP-2348
