### PR TITLE
Exposed the broker-cache header to for AJAX to use

### DIFF
--- a/lib/alephant/broker/load_strategy/revalidate/strategy.rb
+++ b/lib/alephant/broker/load_strategy/revalidate/strategy.rb
@@ -63,6 +63,7 @@ module Alephant
 
           def add_revalidating_headers(data)
              data[:headers] ||= {}
+             data[:headers]['Access-Control-Expose-Headers'] = 'broker-cache'
              data[:headers]['broker-cache'] = 'revalidating'
           end
 

--- a/lib/alephant/broker/version.rb
+++ b/lib/alephant/broker/version.rb
@@ -1,5 +1,5 @@
 module Alephant
   module Broker
-    VERSION = "3.16.0".freeze
+    VERSION = "3.16.1".freeze
   end
 end

--- a/spec/alephant/broker/load_strategy/revalidate/strategy_spec.rb
+++ b/spec/alephant/broker/load_strategy/revalidate/strategy_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe Alephant::Broker::LoadStrategy::Revalidate::Strategy do
   let(:expected_revalidating_content) do
     revalidating_content = expected_content.clone
     revalidating_content[:headers] = {
+      'Access-Control-Expose-Headers' => 'broker-cache',
       'broker-cache' => 'revalidating'
     }
     revalidating_content
@@ -104,6 +105,10 @@ RSpec.describe Alephant::Broker::LoadStrategy::Revalidate::Strategy do
 
         it 'it gets fetched from the cache and returned to the user' do
           expect(subject.load(component_meta)).to eq(expected_revalidating_content)
+        end
+
+        it 'should expose the broker-cache header to AJAX clients' do
+          expect(subject.load(component_meta)[:headers]['Access-Control-Expose-Headers']).to eq('broker-cache')
         end
 
         it 'should contain a revalidating reponse header' do


### PR DESCRIPTION
When we tried to implement the auto-refreshing from the previous PR we noticed that AJAX couldn't see the new header... 

This PR should expose the new header to AJAX requests.