### PR TITLE
Log "value" on debug

### DIFF
--- a/lib/alephant/broker/cache/client.rb
+++ b/lib/alephant/broker/cache/client.rb
@@ -39,7 +39,8 @@ module Alephant
           versioned_key = versioned(key)
           set_ttl       = custom_ttl || ttl
 
-          logger.info("#{self.class}#set - key: #{versioned_key}, value: #{value}, ttl: #{set_ttl}")
+          logger.debug("#{self.class}#set - key: #{versioned_key}, value: #{value}, ttl: #{set_ttl}")
+          logger.info("#{self.class}#set - key: #{versioned_key}, ttl: #{set_ttl}")
 
           @client.set(versioned_key, value, set_ttl)
 

--- a/lib/alephant/broker/version.rb
+++ b/lib/alephant/broker/version.rb
@@ -1,5 +1,5 @@
 module Alephant
   module Broker
-    VERSION = "3.16.1".freeze
+    VERSION = "3.16.2".freeze
   end
 end


### PR DESCRIPTION
### [WS2020-617](https://jira.dev.bbc.co.uk/browse/WS2020-617)

This PR changes the log level for the `value` from `info` to `debug`. This is an attempt to mitigate excessive logging that's causing the AMP broker to crash.

Clients that want the `value` to be logged will need to set the logging level to `debug` for verbose output.

> This PR depends on https://github.com/BBC-News/alephant-logger-json/pull/7 which adds the logging levels.