### PR TITLE
Remove dalli-elasticache wrapper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
   - "2.3"
-  - "jruby"
+  - "jruby-9.1.17.0"
 notifications:
   email:
     recipients:

--- a/alephant-broker.gemspec
+++ b/alephant-broker.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'alephant-sequencer'
   spec.add_runtime_dependency "aws-sdk-sqs"
   spec.add_runtime_dependency "aws-sdk-s3"
-  spec.add_runtime_dependency "dalli-elasticache"
+  spec.add_runtime_dependency "dalli"
   spec.add_runtime_dependency "faraday"
   spec.add_runtime_dependency "crimp"
   spec.add_runtime_dependency "listen", "~> 3.0.0"

--- a/lib/alephant/broker/cache/client.rb
+++ b/lib/alephant/broker/cache/client.rb
@@ -1,4 +1,4 @@
-require 'dalli-elasticache'
+require 'dalli'
 require 'alephant/logger'
 
 module Alephant
@@ -15,8 +15,7 @@ module Alephant
             logger.metric 'NoConfigEndpoint'
             @client = NullClient.new
           else
-            @elasticache ||= ::Dalli::ElastiCache.new(config_endpoint, expires_in: ttl)
-            @client ||= @elasticache.client
+            @client ||= Dalli::Client.new(config_endpoint, expires_in: ttl)
           end
         end
 

--- a/lib/alephant/broker/version.rb
+++ b/lib/alephant/broker/version.rb
@@ -1,5 +1,5 @@
 module Alephant
   module Broker
-    VERSION = "3.17.0".freeze
+    VERSION = "3.18.0".freeze
   end
 end

--- a/spec/alephant/broker/cache/client_spec.rb
+++ b/spec/alephant/broker/cache/client_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe Alephant::Broker::Cache::Client do
+  before do
+    allow(Alephant::Broker).to receive(:config).and_return(config)
+  end
+
+  context 'when creating a new cache client with no cache endpoint' do
+    let(:config) { {} }
+
+    it 'creates a cache client with a null client backend' do
+      expect(Alephant::Broker::Cache::NullClient).to receive(:new)
+      expect(Dalli::Client).not_to receive(:new)
+
+      expect(described_class.new).to be_a described_class
+    end
+  end
+
+  context 'when creating a new cache client with a cache endpoint' do
+    let(:config) { { elasticache_config_endpoint: 'abc123.elasticache.aws.com:11211' } }
+
+    it 'creates a cache client with a null client backend' do
+      expect(Alephant::Broker::Cache::NullClient).not_to receive(:new)
+      expect(Dalli::Client).to receive(:new)
+
+      expect(described_class.new).to be_a described_class
+    end
+  end
+end


### PR DESCRIPTION
The dalli-elasticache wrapper is for auto-discovering elasticache endpoints.
However due to recent updates with AWS Elasticache, this behaviour is no longer
needed. What's more is this gem has a non parameterised 60s timeout when
autodiscovering and causes Alephant to hang for a long time on each request
if the provided elasticache endpoint is unreachable.

This change switches to using the Dalli client directly.