### PR TITLE
Fix vulnerabilities by removing specific versions of dependencies crimp 0.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 rvm:
+  - "jruby-9.1.17.0"
+  - "jruby-1.7.23"
   - "2.3.0"
   - "2.5.1"
-  - "jruby-1.7.23"
-  - "jruby-9.1.17.0"
 notifications:
   email:
     recipients:
@@ -11,5 +11,6 @@ notifications:
     on_failure: change
     on_success: never
 before_install:
-  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
   - gem install bundler -v '< 2'
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem uninstall -v '>= 2' -i $(rvm gemdir) -ax bundler || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: ruby
 rvm:
-  - "jruby-9.1.17.0"
-  - "jruby-1.7.23"
   - "2.3.0"
   - "2.5.1"
+  - "jruby-1.7.23"
+  - "jruby-9.1.17.0"
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ notifications:
       - D&ENewsFrameworksTeam@bbc.co.uk
     on_failure: change
     on_success: never
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'

--- a/alephant-broker.gemspec
+++ b/alephant-broker.gemspec
@@ -41,5 +41,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "aws-sdk-s3"
   spec.add_runtime_dependency "dalli"
   spec.add_runtime_dependency "faraday"
-  spec.add_runtime_dependency "crimp"
+  spec.add_runtime_dependency "crimp", "= 0.1.2"
 end

--- a/alephant-broker.gemspec
+++ b/alephant-broker.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake-rspec", ">= 0.0.2"
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency 'rack', '< 2.0.0' # NOTE: rack 2.0 requires Ruby 2.2+
+  spec.add_development_dependency 'rack'
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "timecop"
@@ -42,5 +42,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "dalli"
   spec.add_runtime_dependency "faraday"
   spec.add_runtime_dependency "crimp"
-  spec.add_runtime_dependency "listen", "~> 3.0.0"
 end

--- a/alephant-broker.gemspec
+++ b/alephant-broker.gemspec
@@ -41,5 +41,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "aws-sdk-s3"
   spec.add_runtime_dependency "dalli"
   spec.add_runtime_dependency "faraday"
-  spec.add_runtime_dependency "crimp", "= 0.2.0"
+  spec.add_runtime_dependency "crimp", "< 1.0"
 end

--- a/alephant-broker.gemspec
+++ b/alephant-broker.gemspec
@@ -41,5 +41,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "aws-sdk-s3"
   spec.add_runtime_dependency "dalli"
   spec.add_runtime_dependency "faraday"
-  spec.add_runtime_dependency "crimp", "= 0.1.2"
+  spec.add_runtime_dependency "crimp", "= 0.2.0"
 end

--- a/lib/alephant/broker/version.rb
+++ b/lib/alephant/broker/version.rb
@@ -1,5 +1,5 @@
 module Alephant
   module Broker
-    VERSION = "3.19.0".freeze
+    VERSION = "3.19.1".freeze
   end
 end


### PR DESCRIPTION
This PR:
- removes gem, listen, to resolve security vulnerabilities introduced by gem, `ffi`, via gem, `listen`.
- locks the version of crimp to 0.2.0 to address the discrepancy in resolving the URIs in broker requests to the MD5 hash stored in the lookup table by the renderer.

Relates to https://github.com/bbc/ws-alephamp-queue-broker/pull/76

https://jira.dev.bbc.co.uk/browse/WS2020-1875